### PR TITLE
Use new logo of Bspb and localize

### DIFF
--- a/client/scripts/configs/i18n.js
+++ b/client/scripts/configs/i18n.js
@@ -1,11 +1,18 @@
-require('../app').config(/* @ngInject */function ($translateProvider, ENDPOINT_URL) {
-  $translateProvider
-    .useUrlLoader(ENDPOINT_URL + '/i18n')
-    .registerAvailableLanguageKeys(['en', 'bg'], {
-      'en_*': 'en',
-      'bg_*': 'bg',
-      '*': 'en'
+require('../app')
+  .config(/* @ngInject */function ($translateProvider, ENDPOINT_URL) {
+    $translateProvider
+      .useUrlLoader(ENDPOINT_URL + '/i18n')
+      .registerAvailableLanguageKeys([ 'en', 'bg' ], {
+        'en_*': 'en',
+        'bg_*': 'bg',
+        '*': 'en'
+      })
+      .determinePreferredLanguage()
+      .preferredLanguage('bg')
+  })
+  .run(/* @ngInject */function ($translate, $rootScope) {
+    $rootScope.$language = $translate.proposedLanguage()
+    $rootScope.$on('$translateChangeSuccess', function (e, params) {
+      $rootScope.$language = params.language
     })
-    .determinePreferredLanguage()
-    .preferredLanguage('bg')
-})
+  })

--- a/client/styles/custom.less
+++ b/client/styles/custom.less
@@ -91,6 +91,13 @@
   vertical-align: middle;
   &.bspb {
     background-image: url('/img/logo-bspb.jpg');
+
+    .lang-bg & {
+      background-image: url('/img/logo-bspb-bg.png');
+    }
+    .lang-en & {
+      background-image: url('/img/logo-bspb-en.png');
+    }
   }
   &.eea {
     background-image: url('/img/logo-eea.jpg');

--- a/client/views/home.html
+++ b/client/views/home.html
@@ -122,7 +122,7 @@
           <div class="row" style="margin-top: 100px">
             <div class="col-md-4 col-xs-6">
               <a href="http://bspb.org" target="_blank">
-                <img class="img-responsive" src="img/logo-bspb.jpg" translate-attr="{alt: 'LOGO_BSPB_ALT'}">
+                <img class="img-responsive" ng-src="img/logo-bspb-{{$language}}.png" translate-attr="{alt: 'LOGO_BSPB_ALT'}">
               </a>
             </div>
             <div class="col-md-4 col-xs-6">

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="" ng-app="sb" ng-class="$state.current.name">
+<html class="no-js" lang="" ng-app="sb" ng-class="[$state.current.name, 'lang-'+$language]">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
On home page the logo is changed with interpolation, while on form pages the logo is applied with css, so a global `lang-XX` is added to `html` and appropriate overrides for the logo.