### PR TITLE
Don't send content length for gzipped streams

### DIFF
--- a/client/scripts/services/trackService.js
+++ b/client/scripts/services/trackService.js
@@ -8,8 +8,12 @@ require('../app').service('Track', /* @ngInject */function ($filter, $http) {
       .then(function (response) {
         if (!response || !response.data || !response.data.gpx || !response.data.gpx.trk || !response.data.gpx.trk.trkseg) return []
         var points = []
-        response.data.gpx.trk.trkseg.forEach(function (trkseg) {
-          var trkpt = trkseg.trkpt
+        var segs = response.data.gpx.trk.trkseg
+        if (!Array.isArray(segs) && segs.trkpt) {
+          segs = segs.trkpt
+        }
+        segs.forEach(function (trkseg) {
+          var trkpt = trkseg.trkpt || trkseg
           if (!trkpt || !trkpt._lat || !trkpt._lon) return
           var pp = {
             latitude: parseFloat(trkpt._lat),

--- a/server/initializers/filestorage.js
+++ b/server/initializers/filestorage.js
@@ -86,7 +86,7 @@ module.exports = {
           try {
             var meta = JSON.parse(data)
             api.log('blob', 'debug', { id: id, meta: meta })
-            var inflator = api.filestorage.inflator(meta.type || 'application/octet-stream', meta.filters || {})
+            var inflator = api.filestorage.inflator(meta.type || 'application/octet-stream', meta.filters || {}, meta)
             var strm = self.storage.createReadStream(meta.blob).pipe(inflator)
             next(null, strm, meta)
           } catch (e) {
@@ -113,8 +113,9 @@ module.exports = {
         }))
       },
 
-      inflator: function (mime, filters) {
+      inflator: function (mime, filters, meta) {
         if (filters.gzip) {
+          delete meta.length
           return zlib.createUnzip()
         }
         return new stream.PassThrough()


### PR DESCRIPTION
This is wrong as the length is actually of the compressed content