### PR TITLE
fix public birds page background

### DIFF
--- a/client/styles/custom.less
+++ b/client/styles/custom.less
@@ -286,7 +286,6 @@ input[type=file] {
 .birds {
   .main {
     padding: 50px 0;
-    background-color: #f0f0f0;
   }
 }
 


### PR DESCRIPTION
Fix stats background in birds public page

Before:
![before](https://user-images.githubusercontent.com/186129/49162317-4ddcd580-f333-11e8-9294-8595a55fa7d3.png)

After:
![after](https://user-images.githubusercontent.com/186129/49162326-56351080-f333-11e8-9328-3175d3edaadc.png)
