### PR TITLE
Handle no server connection in lists and allow retry

### DIFF
--- a/client/scripts/directives/monitoringList.js
+++ b/client/scripts/directives/monitoringList.js
@@ -1,0 +1,10 @@
+require('../app').directive('monitoringList', /* @ngInject */function () {
+  return {
+    restrict: 'EA',
+    transclude: true,
+    templateUrl: '/views/directives/monitoring_list.html',
+    scope: {
+      monitoringController: '<'
+    }
+  }
+})

--- a/client/views/directives/monitoring_list.html
+++ b/client/views/directives/monitoring_list.html
@@ -1,0 +1,26 @@
+<div
+  class="row"
+  ng-if="monitoringController.tab == 'list'"
+  infinite-scroll="monitoringController.nextPage()"
+  infinite-scroll-distance="10"
+  infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages || monitoringController.offline"
+  infinite-scroll-listen-for-event="list:filtered"
+>
+  <div class="col-lg-12">
+    <ng-transclude></ng-transclude>
+  </div>
+  <div class="col-lg-12">
+    <div class="text-center" ng-if="monitoringController.loading">
+      <i ng-if="monitoringController.loading" class="fa fa-spinner fa-2x fa-spin"></i>
+    </div>
+    <div ng-if="monitoringController.offline" class="alert alert-warning">
+      <button
+        ng-if="monitoringController.offline" type="button" class="btn btn-default btn-outline"
+        ng-click="monitoringController.retry()"
+      >
+        <i class="fa fa-refresh"></i>
+      </button>
+      {{::'NO_CONNECTION_WITH_SERVER' | translate}}
+    </div>
+  </div>
+</div>

--- a/client/views/monitorings/list_birds.html
+++ b/client/views/monitorings/list_birds.html
@@ -125,71 +125,58 @@
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          BIRDS_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="location" translate>
-          BIRDS_LIST_TABLE_LOCATION
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          BIRDS_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          BIRDS_LIST_TABLE_UPDATED
-        </th>
-        <th sb-sorting="species.label[$language]" translate>
-          BIRDS_LIST_TABLE_SPECIES
-        </th>
-        <th translate>
-          BIRDS_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{::row.location}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>
-          {{row.getSpecies().label[$language]}}<br/>
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td>{{::row.getCount($language)}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?10:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th ng-if="$user.canAccess(monitoringController.formName)"
+          sb-sorting="getUser().getName()" translate>
+        BIRDS_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="location" translate>
+        BIRDS_LIST_TABLE_LOCATION
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        BIRDS_LIST_TABLE_DATE
+      </th>
+      <th
+        sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+        BIRDS_LIST_TABLE_UPDATED
+      </th>
+      <th sb-sorting="species.label[$language]" translate>
+        BIRDS_LIST_TABLE_SPECIES
+      </th>
+      <th translate>
+        BIRDS_LIST_TABLE_COUNT
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+      ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+      <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+      <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+      <td>{{::row.location}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>
+        {{row.getSpecies().label[$language]}}<br/>
+        <strong>{{row.getSpecies().label.la}}</strong>
+      </td>
+      <td>{{::row.getCount($language)}}</td>
+    </tr>
+    </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_cbm.html
+++ b/client/views/monitorings/list_cbm.html
@@ -146,96 +146,83 @@
     <p ng-if="monitoringController.count > monitoringController.rows.length" class="text-warning">
       {{'CBM_LIST_MAP_SHOWN_RECORDS_WARNING' | translate: monitoringController.resultRowsTranslationValues()}}
       <button ng-if="$user.canAccess(monitoringController.formName) && !monitoringController.loading" type="button" class="btn btn-default btn-xs"
-              ng-click="monitoringController.nextPage(-1)" translate>CBM_LIST_MAP_BUTTON_SHOW_ALL
+        ng-click="monitoringController.nextPage(-1)" translate>CBM_LIST_MAP_BUTTON_SHOW_ALL
       </button>
     </p>
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          CBM_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="getZone().location.id" translate>
-          CBM_LIST_TABLE_LOCATION
-        </th>
-        <th sb-sorting="zone.id" translate>
-          CBM_LIST_TABLE_ZONE
-        </th>
-        <th
-          sb-sorting="visit.label[$language]" translate>
-          CBM_LIST_TABLE_VISIT
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          CBM_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          CBM_LIST_TABLE_UPDATED
-        </th>
-        <th sb-sorting="species.label[$language]" translate>
-          CBM_LIST_TABLE_SPECIES
-        </th>
-        <th
-          sb-sorting="plot.label[$language]" translate>
-          CBM_LIST_TABLE_PLOT
-        </th>
-        <th sb-sorting="distance.label[$language]" translate>
-          CBM_LIST_TABLE_DISTANCE
-        </th>
-        <th
-          sb-sorting="count" translate>
-          CBM_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{row.getZone().location | locationLabel}}</td>
-        <td>{{::row.zone}}</td>
-        <td>{{::row.visit.label[$language]}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>
-          {{row.getSpecies().label[$language]}}<br/>
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td>{{::row.plot.label[$language]}}</td>
-        <td>{{::row.distance.label[$language]}}</td>
-        <td>{{::row.count}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?10:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+  <thead>
+  <tr>
+    <th ng-click="monitoringController.toggleSelected()">
+      <input type="checkbox" ng-checked="monitoringController.allSelected">
+    </th>
+    <th sb-sorting="id">#</th>
+    <th ng-if="$user.canAccess(monitoringController.formName)"
+        sb-sorting="getUser().getName()" translate>
+      CBM_LIST_TABLE_USER
+    </th>
+    <th
+      sb-sorting="getZone().location.id" translate>
+      CBM_LIST_TABLE_LOCATION
+    </th>
+    <th sb-sorting="zone.id" translate>
+      CBM_LIST_TABLE_ZONE
+    </th>
+    <th
+      sb-sorting="visit.label[$language]" translate>
+      CBM_LIST_TABLE_VISIT
+    </th>
+    <th
+      sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+      CBM_LIST_TABLE_DATE
+    </th>
+    <th
+      sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+      CBM_LIST_TABLE_UPDATED
+    </th>
+    <th sb-sorting="species.label[$language]" translate>
+      CBM_LIST_TABLE_SPECIES
+    </th>
+    <th
+      sb-sorting="plot.label[$language]" translate>
+      CBM_LIST_TABLE_PLOT
+    </th>
+    <th sb-sorting="distance.label[$language]" translate>
+      CBM_LIST_TABLE_DISTANCE
+    </th>
+    <th
+      sb-sorting="count" translate>
+      CBM_LIST_TABLE_COUNT
+    </th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr
+    ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+    ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+    <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+      type="checkbox"
+      ng-checked="row.$selected">
+    </td>
+    <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+    <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+    <td>{{row.getZone().location | locationLabel}}</td>
+    <td>{{::row.zone}}</td>
+    <td>{{::row.visit.label[$language]}}</td>
+    <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+    <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+    <td>
+      {{row.getSpecies().label[$language]}}<br/>
+      <strong>{{row.getSpecies().label.la}}</strong>
+    </td>
+    <td>{{::row.plot.label[$language]}}</td>
+    <td>{{::row.distance.label[$language]}}</td>
+    <td>{{::row.count}}</td>
+  </tr>
+  </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_ciconia.html
+++ b/client/views/monitorings/list_ciconia.html
@@ -115,60 +115,46 @@
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          CICONIA_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="location" translate>
-          CICONIA_LIST_TABLE_LOCATION
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          CICONIA_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          CICONIA_LIST_TABLE_UPDATED
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{::row.location}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?5:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th ng-if="$user.canAccess(monitoringController.formName)"
+          sb-sorting="getUser().getName()" translate>
+        CICONIA_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="location" translate>
+        CICONIA_LIST_TABLE_LOCATION
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        CICONIA_LIST_TABLE_DATE
+      </th>
+      <th
+        sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+        CICONIA_LIST_TABLE_UPDATED
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+      ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+      <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+      <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+      <td>{{::row.location}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+    </tr>
+    </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_herptiles.html
+++ b/client/views/monitorings/list_herptiles.html
@@ -125,72 +125,58 @@
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          HERPTILES_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="location" translate>
-          HERPTILES_LIST_TABLE_LOCATION
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          HERPTILES_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          HERPTILES_LIST_TABLE_UPDATED
-        </th>
-        <th sb-sorting="species.label[$language]" translate>
-          HERPTILES_LIST_TABLE_SPECIES
-        </th>
-        <th
-          sb-sorting="count" translate>
-          HERPTILES_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{::row.location}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>
-          {{row.getSpecies().label[$language]}}<br/>
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td>{{::row.count}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?10:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th ng-if="$user.canAccess(monitoringController.formName)"
+          sb-sorting="getUser().getName()" translate>
+        HERPTILES_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="location" translate>
+        HERPTILES_LIST_TABLE_LOCATION
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        HERPTILES_LIST_TABLE_DATE
+      </th>
+      <th
+        sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+        HERPTILES_LIST_TABLE_UPDATED
+      </th>
+      <th sb-sorting="species.label[$language]" translate>
+        HERPTILES_LIST_TABLE_SPECIES
+      </th>
+      <th
+        sb-sorting="count" translate>
+        HERPTILES_LIST_TABLE_COUNT
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+      ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+      <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+      <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+      <td>{{::row.location}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>
+        {{row.getSpecies().label[$language]}}<br/>
+        <strong>{{row.getSpecies().label.la}}</strong>
+      </td>
+      <td>{{::row.count}}</td>
+    </tr>
+    </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_invertebrates.html
+++ b/client/views/monitorings/list_invertebrates.html
@@ -124,72 +124,58 @@
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          INVERTEBRATES_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="location" translate>
-          INVERTEBRATES_LIST_TABLE_LOCATION
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          INVERTEBRATES_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          INVERTEBRATES_LIST_TABLE_UPDATED
-        </th>
-        <th sb-sorting="species.label[$language]" translate>
-          INVERTEBRATES_LIST_TABLE_SPECIES
-        </th>
-        <th
-          sb-sorting="count" translate>
-          INVERTEBRATES_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{::row.location}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>
-          {{row.getSpecies().label[$language]}}<br/>
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td>{{::row.count}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?10:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th ng-if="$user.canAccess(monitoringController.formName)"
+          sb-sorting="getUser().getName()" translate>
+        INVERTEBRATES_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="location" translate>
+        INVERTEBRATES_LIST_TABLE_LOCATION
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        INVERTEBRATES_LIST_TABLE_DATE
+      </th>
+      <th
+        sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+        INVERTEBRATES_LIST_TABLE_UPDATED
+      </th>
+      <th sb-sorting="species.label[$language]" translate>
+        INVERTEBRATES_LIST_TABLE_SPECIES
+      </th>
+      <th
+        sb-sorting="count" translate>
+        INVERTEBRATES_LIST_TABLE_COUNT
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+      ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+      <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+      <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+      <td>{{::row.location}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>
+        {{row.getSpecies().label[$language]}}<br/>
+        <strong>{{row.getSpecies().label.la}}</strong>
+      </td>
+      <td>{{::row.count}}</td>
+    </tr>
+    </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_mammals.html
+++ b/client/views/monitorings/list_mammals.html
@@ -124,72 +124,58 @@
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          MAMMALS_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="location" translate>
-          MAMMALS_LIST_TABLE_LOCATION
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          MAMMALS_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          MAMMALS_LIST_TABLE_UPDATED
-        </th>
-        <th sb-sorting="species.label[$language]" translate>
-          MAMMALS_LIST_TABLE_SPECIES
-        </th>
-        <th
-          sb-sorting="count" translate>
-          MAMMALS_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{::row.location}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>
-          {{row.getSpecies().label[$language]}}<br/>
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td>{{::row.count}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?10:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th ng-if="$user.canAccess(monitoringController.formName)"
+          sb-sorting="getUser().getName()" translate>
+        MAMMALS_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="location" translate>
+        MAMMALS_LIST_TABLE_LOCATION
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        MAMMALS_LIST_TABLE_DATE
+      </th>
+      <th
+        sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+        MAMMALS_LIST_TABLE_UPDATED
+      </th>
+      <th sb-sorting="species.label[$language]" translate>
+        MAMMALS_LIST_TABLE_SPECIES
+      </th>
+      <th
+        sb-sorting="count" translate>
+        MAMMALS_LIST_TABLE_COUNT
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+      ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+      <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+      <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+      <td>{{::row.location}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>
+        {{row.getSpecies().label[$language]}}<br/>
+        <strong>{{row.getSpecies().label.la}}</strong>
+      </td>
+      <td>{{::row.count}}</td>
+    </tr>
+    </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_plants.html
+++ b/client/views/monitorings/list_plants.html
@@ -124,72 +124,58 @@
     <list-map rows="monitoringController.selectedRows.length > 0 ? monitoringController.selectedRows : monitoringController.rows" ctrl="monitoringController.map"></list-map>
   </div>
 </div>
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th ng-if="$user.canAccess(monitoringController.formName)"
-            sb-sorting="getUser().getName()" translate>
-          PLANTS_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="location" translate>
-          PLANTS_LIST_TABLE_LOCATION
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          PLANTS_LIST_TABLE_DATE
-        </th>
-        <th
-          sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
-          PLANTS_LIST_TABLE_UPDATED
-        </th>
-        <th sb-sorting="species.label[$language]" translate>
-          PLANTS_LIST_TABLE_SPECIES
-        </th>
-        <th
-          sb-sorting="count" translate>
-          PLANTS_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
-        ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
-        <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
-        <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
-        <td>{{::row.location}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
-        <td>
-          {{row.getSpecies().label[$language]}}<br/>
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td>{{::row.count}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading">
-      <tr>
-        <th colspan="{{::$user.canAccess(monitoringController.formName)?10:9}}" class="text-center">
-          <i class="fa fa-spinner fa-2x fa-spin"></i>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
-  </div>
-</div>
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th ng-if="$user.canAccess(monitoringController.formName)"
+          sb-sorting="getUser().getName()" translate>
+        PLANTS_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="location" translate>
+        PLANTS_LIST_TABLE_LOCATION
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        PLANTS_LIST_TABLE_DATE
+      </th>
+      <th
+        sb-sorting="updatedAt|date:'yyyyMMddHHmmss'" translate>
+        PLANTS_LIST_TABLE_UPDATED
+      </th>
+      <th sb-sorting="species.label[$language]" translate>
+        PLANTS_LIST_TABLE_SPECIES
+      </th>
+      <th
+        sb-sorting="count" translate>
+        PLANTS_LIST_TABLE_COUNT
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse"
+      ng-click="$state.go('.detail', {id: row.id, offset: $index})" ng-class="{info: row.$selected}">
+      <td ng-click="$event.stopPropagation(); monitoringController.toggleSelected(row)"><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td><a href ui-sref=".detail({id: row.id, offset: $index})">{{::row.id}}</a></td>
+      <td ng-if="::$user.canAccess(monitoringController.formName)">{{row.getUser().getName()}}</td>
+      <td>{{::row.location}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>{{::row.updatedAt|date:'d.MM.yyyy HH:mm'}}</td>
+      <td>
+        {{row.getSpecies().label[$language]}}<br/>
+        <strong>{{row.getSpecies().label.la}}</strong>
+      </td>
+      <td>{{::row.count}}</td>
+    </tr>
+    </tbody>
+  </table>
+</monitoring-list>

--- a/client/views/monitorings/list_public.html
+++ b/client/views/monitorings/list_public.html
@@ -82,70 +82,58 @@
   </div>
 </div>
 
-<div ng-if="monitoringController.tab == 'list'"
-     class="row"
-     infinite-scroll="monitoringController.nextPage()"
-     infinite-scroll-distance="10"
-     infinite-scroll-disabled="monitoringController.loading || monitoringController.endOfPages"
-     infinite-scroll-listen-for-event="list:filtered">
-  <div class="col-lg-12">
-    <table class="table table-striped table-hover" sb-table="monitoringController.order">
-      <thead>
-      <tr>
-        <th ng-click="monitoringController.toggleSelected()">
-          <input type="checkbox" ng-checked="monitoringController.allSelected">
-        </th>
-        <th sb-sorting="id">#</th>
-        <th sb-sorting="getUser().getName()" translate>
-          PUBLIC_LIST_TABLE_USER
-        </th>
-        <th
-          sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
-          PUBLIC_LIST_TABLE_DATE
-        </th>
-        <th ng-if="monitoringController.formSpeciesType" sb-sorting="species.label[$language]" translate>
-          PUBLIC_LIST_TABLE_SPECIES
-        </th>
-        <th ng-if="::monitoringController.formDef.hasCount" sb-sorting="count" translate>
-          PUBLIC_LIST_TABLE_COUNT
-        </th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr
-        ng-click="monitoringController.toggleSelected(row)"
-        ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse">
-        <td><input
-          type="checkbox"
-          ng-checked="row.$selected">
-        </td>
-        <td>{{::row.id}}</td>
-        <td>{{::(row.user.firstName + ' ' + row.user.lastName)}}</td>
-        <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
-        <td ng-if="::monitoringController.formSpeciesType">
-          {{row.getSpecies().label[$language]}}<br />
-          <strong>{{row.getSpecies().label.la}}</strong>
-        </td>
-        <td ng-if="::monitoringController.formDef.hasCount">{{::row.getCount() || row.count}}</td>
-      </tr>
-      </tbody>
-      <tfoot ng-if="monitoringController.loading || !monitoringController.rows.length">
-      <tr>
-        <th colspan="{{::3+(monitoringController.formSpeciesType?1:0)+(monitoringController.formDef.hasCount?1:0)}}" class="text-center">
-          <div
-            ng-if="!monitoringController.loading && monitoringController.db.species[monitoringController.formSpeciesType][monitoringController.filter.species].sensitive"
-            class="lead text-warning" translate>
-            PUBLIC_LIST_WARN_SENSITIVE_SPECIES
-          </div>
-          <div
-            ng-if="!monitoringController.loading && !monitoringController.db.species[monitoringController.formSpeciesType][monitoringController.filter.species].sensitive"
-            class="lead" translate>
-            PUBLIC_LIST_NO_RESULTS
-          </div>
-          <div ng-if="monitoringController.loading"><i class="fa fa-spinner fa-2x fa-spin"></i></div>
-        </th>
-      </tr>
-      </tfoot>
-    </table>
+<monitoring-list monitoring-controller="monitoringController">
+  <table class="table table-striped table-hover" sb-table="monitoringController.order">
+    <thead>
+    <tr>
+      <th ng-click="monitoringController.toggleSelected()">
+        <input type="checkbox" ng-checked="monitoringController.allSelected">
+      </th>
+      <th sb-sorting="id">#</th>
+      <th sb-sorting="getUser().getName()" translate>
+        PUBLIC_LIST_TABLE_USER
+      </th>
+      <th
+        sb-sorting="observationDateTime|date:'yyyyMMddHHmmss'" translate>
+        PUBLIC_LIST_TABLE_DATE
+      </th>
+      <th ng-if="monitoringController.formSpeciesType" sb-sorting="species.label[$language]" translate>
+        PUBLIC_LIST_TABLE_SPECIES
+      </th>
+      <th ng-if="::monitoringController.formDef.hasCount" sb-sorting="count" translate>
+        PUBLIC_LIST_TABLE_COUNT
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr
+      ng-click="monitoringController.toggleSelected(row)"
+      ng-repeat="row in monitoringController.rows | orderBy:monitoringController.order.key:monitoringController.order.reverse">
+      <td><input
+        type="checkbox"
+        ng-checked="row.$selected">
+      </td>
+      <td>{{::row.id}}</td>
+      <td>{{::(row.user.firstName + ' ' + row.user.lastName)}}</td>
+      <td>{{::row.observationDateTime|date:'d.MM.yyyy HH:mm'}}</td>
+      <td ng-if="::monitoringController.formSpeciesType">
+        {{row.getSpecies().label[$language]}}<br />
+        <strong>{{row.getSpecies().label.la}}</strong>
+      </td>
+      <td ng-if="::monitoringController.formDef.hasCount">{{::row.getCount() || row.count}}</td>
+    </tr>
+    </tbody>
+  </table>
+  <div ng-if="!monitoringController.loading && !monitoringController.offline && !monitoringController.rows.length" class="text-center">
+    <div
+      ng-if="monitoringController.db.species[monitoringController.formSpeciesType][monitoringController.filter.species].sensitive"
+      class="lead text-warning" translate>
+      PUBLIC_LIST_WARN_SENSITIVE_SPECIES
+    </div>
+    <div
+      ng-if="!monitoringController.db.species[monitoringController.formSpeciesType][monitoringController.filter.species].sensitive"
+      class="lead" translate>
+      PUBLIC_LIST_NO_RESULTS
+    </div>
   </div>
-</div>
+</monitoring-list>

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -933,5 +933,6 @@
     "LIST_FILTER_RADIUS_PLACEHOLDER": "Изберете радиус",
     "LIST_FILTER_GEOLOCATION": "Геолокация",
     "LIST_FILTER_GEOLOCATION_PLACEHOLDER": "Изберете геолокация",
-    "LIST_FILTER_GEOLOCATION_BTN_CLEAR_LABEL": "Изчисти"
+    "LIST_FILTER_GEOLOCATION_BTN_CLEAR_LABEL": "Изчисти",
+    "NO_CONNECTION_WITH_SERVER": "Няма връзка със сървъра."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -933,5 +933,6 @@
     "LIST_FILTER_RADIUS_PLACEHOLDER": "Select radius",
     "LIST_FILTER_GEOLOCATION": "Geolocation",
     "LIST_FILTER_GEOLOCATION_PLACEHOLDER": "Select geolocation",
-    "LIST_FILTER_GEOLOCATION_BTN_CLEAR_LABEL": "Clear"
+    "LIST_FILTER_GEOLOCATION_BTN_CLEAR_LABEL": "Clear",
+    "NO_CONNECTION_WITH_SERVER": "No connection with server."
 }


### PR DESCRIPTION
In form lists instead of infinitely retrying to fetch next page, displays an error message and retry button.

* [bg message](https://poeditor.com/projects/po_edit?order=&filter=&id=146255&id_language=24&search=NO_CONNECTION_WITH_SERVER)
* [en message](https://poeditor.com/projects/po_edit?order=&filter=&id=146255&id_language=43&search=NO_CONNECTION_WITH_SERVER)

![Screenshot from 2019-05-02 10-18-07](https://user-images.githubusercontent.com/185580/57060864-9a9e5100-6cc3-11e9-896e-a7fb01293a31.png)


To simulate - login to [staging](http://smartbirds-staging.herokuapp.com/), disable connection, open a form