### PR TITLE
Fill form geolocation with current location

### DIFF
--- a/client/scripts/directives/field.js
+++ b/client/scripts/directives/field.js
@@ -86,6 +86,7 @@ require('../app').directive('field', /* @ngInject */function ($q, Raven) {
 
       var getCurrentPositionSuccess = function (pos) {
         field.loading = false
+        if (!pos || !pos.coords) return
         var args = {
           timestamp: pos.timestamp,
           latitude: pos.coords.latitude,

--- a/client/views/fields/geolocation.html
+++ b/client/views/fields/geolocation.html
@@ -1,0 +1,31 @@
+<sb-include src="/views/fields/container.html">
+  <div ng-class="::field.hasGeolocation ? 'input-group' : ''">
+    <input type="number"
+           step="{{::field.$attrs.step}}"
+           min="{{::field.$attrs.min}}"
+           max="{{::field.$attrs.max}}"
+           pattern="{{::field.$attrs.pattern}}"
+           class="form-control"
+           id="{{::field.name}}"
+           name="{{::field.name}}"
+           aria-describedby="{{::field.name}}HelpBlock"
+           placeholder="{{::field.placeholder}}"
+           ng-model="field.model"
+           ng-change="field.onSelect()"
+           ng-required="::field.required"
+           parse-number>
+    <span ng-if="::field.hasGeolocation" class="input-group-btn">
+      <button
+        class="btn btn-primary"
+        type="button"
+        ng-click="field.getCurrentLocation()"
+        ng-disabled="field.loading"
+      >
+        <i
+          class="fa fa-fw"
+          ng-class="field.loading ? 'fa-spinner fa-spin' : 'fa-map-marker'"
+        ></i>
+      </button>
+    </span>
+  </div>
+</sb-include>

--- a/client/views/monitorings/birds.html
+++ b/client/views/monitorings/birds.html
@@ -33,50 +33,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-8 col-lg-7">
-      <div class="row">
-        <div class="col-md-6">
-          <field name="latitude" type="float" required="true"
-                 label="{{'BIRDS_DETAIL_LATITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.latitude"></field>
-        </div>
-        <div class="col-md-6">
-          <field name="longitude" type="float" required="true"
-                 label="{{'BIRDS_DETAIL_LONGITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.longitude"></field>
-        </div>
-        <div class="col-md-12">
-          <div class="text-right">
-            <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
-          </div>
-          <ui-gmap-google-map
-            center="monitoringDetailController.map.center"
-            pan="true"
-            zoom="monitoringDetailController.map.zoom"
-            events="{click: monitoringDetailController.map.click}"
-            options="{mapTypeId: 'hybrid', clickableIcons: false}">
-            <ui-gmap-polyline
-              ng-if="monitoringDetailController.track.length"
-              path="monitoringDetailController.track"
-              stroke="{color: '#36c', weight: 3}"
-              editable="false"
-              draggable="false"
-              geodesic="true"
-              visible="true"
-              fit="true"
-              static="true"
-            ></ui-gmap-polyline>
-            <ui-gmap-marker
-              ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-              coords="monitoringDetailController.map.poi"
-              idKey="'coords'"
-            ></ui-gmap-marker>
-          </ui-gmap-google-map>
-        </div>
-      </div>
-    </div>
+    <div class="col-md-8 col-lg-7" ng-include="'/views/monitorings/geolocation.html'"></div>
     <div class="col-md-4 col-lg-5">
       <div class="row">
         <div class="col-md-6">

--- a/client/views/monitorings/cbm.html
+++ b/client/views/monitorings/cbm.html
@@ -33,44 +33,17 @@
 
   <div class="row">
     <div class="col-md-8 col-lg-7">
-      <field name="zone" type="zone" required="true"
-             label="{{'CBM_DETAIL_PLACE' | translate}}"
-             on-select="monitoringDetailController.onZoneSelected()"
-             model="monitoringDetailController.data.zone"></field>
-
-      <div class="text-right">
-        <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
+      <div class="row">
+        <div class="col-md-12">
+        <field name="zone" type="zone" required="true"
+               label="{{'CBM_DETAIL_PLACE' | translate}}"
+               on-select="monitoringDetailController.onZoneSelected()"
+               model="monitoringDetailController.data.zone"></field>
+        </div>
       </div>
-      <ui-gmap-google-map
+      <ng-include
         ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-        center="monitoringDetailController.map.center"
-        zoom="monitoringDetailController.map.zoom"
-        options="{mapTypeId: 'hybrid', clickableIcons: false}">
-        <ui-gmap-polygon
-          ng-if="monitoringDetailController.data.getZone && monitoringDetailController.data.getZone().coordinates.length"
-          path="monitoringDetailController.data.getZone().coordinates"
-          static="true"
-          fill="{color: '#00f', opacitiy: 0.7}"
-          stroke="{color: '#00f', opacity: 1, weight: 3}"
-          geodesic="true"
-          fit="false"
-          events="{click: monitoringDetailController.map.click}"
-        ></ui-gmap-polygon>
-        <ui-gmap-polyline
-          ng-if="monitoringDetailController.track.length"
-          path="monitoringDetailController.track"
-          stroke="{color: '#36c', weight: 3}"
-          editable="false"
-          draggable="false"
-          geodesic="true"
-          visible="true"
-          fit="true"
-          static="true"
-        ></ui-gmap-polyline>
-        <ui-gmap-marker coords="monitoringDetailController.map.poi"
-                        idKey="'coords'"
-        ></ui-gmap-marker>
-      </ui-gmap-google-map>
+        src="'/views/monitorings/geolocation.html'"></ng-include>
     </div>
 
     <div class="col-md-4 col-lg-5">

--- a/client/views/monitorings/ciconia.html
+++ b/client/views/monitorings/ciconia.html
@@ -22,48 +22,7 @@
   <h5 translate>CICONIA_DETAIL_PARAGRAPH_1_TITLE</h5>
   <div class="row">
     <div class="col-md-8 col-lg-7">
-      <div class="row">
-        <div class="col-md-6">
-          <field name="latitude" type="float" required="true"
-                 label="{{'CICONIA_DETAIL_LATITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.latitude"></field>
-        </div>
-        <div class="col-md-6">
-          <field name="longitude" type="float" required="true"
-                 label="{{'CICONIA_DETAIL_LONGITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.longitude"></field>
-        </div>
-        <div class="col-md-12">
-          <div class="text-right">
-            <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
-          </div>
-          <ui-gmap-google-map
-            center="monitoringDetailController.map.center"
-            pan="true"
-            zoom="monitoringDetailController.map.zoom"
-            events="{click: monitoringDetailController.map.click}"
-            options="{mapTypeId: 'hybrid', clickableIcons: false}">
-            <ui-gmap-polyline
-              ng-if="monitoringDetailController.track.length"
-              path="monitoringDetailController.track"
-              stroke="{color: '#36c', weight: 3}"
-              editable="false"
-              draggable="false"
-              geodesic="true"
-              visible="true"
-              fit="true"
-              static="true"
-            ></ui-gmap-polyline>
-            <ui-gmap-marker
-              ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-              coords="monitoringDetailController.map.poi"
-              idKey="'coords'"
-            ></ui-gmap-marker>
-          </ui-gmap-google-map>
-        </div>
-      </div>
+      <div class="row" ng-include="'/views/monitorings/geolocation.html'"></div>
     </div>
     <div class="col-md-4 col-lg-5">
       <div class="row">

--- a/client/views/monitorings/geolocation.html
+++ b/client/views/monitorings/geolocation.html
@@ -1,0 +1,54 @@
+<div class="row">
+  <div class="col-md-6">
+    <field name="latitude" type="geolocation.latitude" required="true"
+           label="{{'DETAIL_LATITUDE' | translate}}"
+           on-select="monitoringDetailController.data.longitude=longitude;monitoringDetailController.updateFromModel()"
+           model="monitoringDetailController.data.latitude"></field>
+  </div>
+  <div class="col-md-6">
+    <field name="longitude" type="geolocation.longitude" required="true"
+           label="{{'DETAIL_LONGITUDE' | translate}}"
+           on-select="monitoringDetailController.data.latitude=latitude;monitoringDetailController.updateFromModel()"
+           model="monitoringDetailController.data.longitude"></field>
+  </div>
+  <div class="col-md-12">
+    <div class="text-right">
+      <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
+    </div>
+  </div>
+  <div class="col-md-12">
+    <ui-gmap-google-map
+      center="monitoringDetailController.map.center"
+      pan="true"
+      zoom="monitoringDetailController.map.zoom"
+      events="{click: monitoringDetailController.map.click}"
+      options="{mapTypeId: 'hybrid', clickableIcons: false}">
+      <ui-gmap-polygon
+        ng-if="monitoringDetailController.data.getZone && monitoringDetailController.data.getZone().coordinates.length"
+        path="monitoringDetailController.data.getZone().coordinates"
+        static="true"
+        fill="{color: '#00f', opacitiy: 0.7}"
+        stroke="{color: '#00f', opacity: 1, weight: 3}"
+        geodesic="true"
+        fit="false"
+        events="{click: monitoringDetailController.map.click}"
+      ></ui-gmap-polygon>
+      <ui-gmap-polyline
+        ng-if="monitoringDetailController.track.length"
+        path="monitoringDetailController.track"
+        stroke="{color: '#36c', weight: 3}"
+        editable="false"
+        draggable="false"
+        geodesic="true"
+        visible="true"
+        fit="true"
+        static="true"
+      ></ui-gmap-polyline>
+      <ui-gmap-marker
+        ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
+        coords="monitoringDetailController.map.poi"
+        idKey="'coords'"
+      ></ui-gmap-marker>
+    </ui-gmap-google-map>
+  </div>
+</div>

--- a/client/views/monitorings/herptiles.html
+++ b/client/views/monitorings/herptiles.html
@@ -20,50 +20,7 @@
   <div ng-include="'/views/monitorings/common.html'"></div>
 
   <div class="row">
-    <div class="col-md-8 col-lg-7">
-      <div class="row">
-        <div class="col-md-6">
-          <field name="latitude" type="float" required="true"
-                 label="{{'HERPTILES_DETAIL_LATITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.latitude"></field>
-        </div>
-        <div class="col-md-6">
-          <field name="longitude" type="float" required="true"
-                 label="{{'HERPTILES_DETAIL_LONGITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.longitude"></field>
-        </div>
-        <div class="col-md-12">
-          <div class="text-right">
-            <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
-          </div>
-          <ui-gmap-google-map
-            center="monitoringDetailController.map.center"
-            pan="true"
-            zoom="monitoringDetailController.map.zoom"
-            events="{click: monitoringDetailController.map.click}"
-            options="{mapTypeId: 'hybrid', clickableIcons: false}">
-            <ui-gmap-polyline
-              ng-if="monitoringDetailController.track.length"
-              path="monitoringDetailController.track"
-              stroke="{color: '#36c', weight: 3}"
-              editable="false"
-              draggable="false"
-              geodesic="true"
-              visible="true"
-              fit="true"
-              static="true"
-            ></ui-gmap-polyline>
-            <ui-gmap-marker
-              ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-              coords="monitoringDetailController.map.poi"
-              idKey="'coords'"
-            ></ui-gmap-marker>
-          </ui-gmap-google-map>
-        </div>
-      </div>
-    </div>
+    <div class="col-md-8 col-lg-7" ng-include="'/views/monitorings/geolocation.html'"></div>
     <div class="col-md-4 col-lg-5">
       <div class="row">
         <div class="col-md-12">

--- a/client/views/monitorings/invertebrates.html
+++ b/client/views/monitorings/invertebrates.html
@@ -20,50 +20,7 @@
   <div ng-include="'/views/monitorings/common.html'"></div>
 
   <div class="row">
-    <div class="col-md-8 col-lg-7">
-      <div class="row">
-        <div class="col-md-6">
-          <field name="latitude" type="float" required="true"
-                 label="{{'INVERTEBRATES_DETAIL_LATITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.latitude"></field>
-        </div>
-        <div class="col-md-6">
-          <field name="longitude" type="float" required="true"
-                 label="{{'INVERTEBRATES_DETAIL_LONGITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.longitude"></field>
-        </div>
-        <div class="col-md-12">
-          <div class="text-right">
-            <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
-          </div>
-          <ui-gmap-google-map
-            center="monitoringDetailController.map.center"
-            pan="true"
-            zoom="monitoringDetailController.map.zoom"
-            events="{click: monitoringDetailController.map.click}"
-            options="{mapTypeId: 'hybrid', clickableIcons: false}">
-            <ui-gmap-polyline
-              ng-if="monitoringDetailController.track.length"
-              path="monitoringDetailController.track"
-              stroke="{color: '#36c', weight: 3}"
-              editable="false"
-              draggable="false"
-              geodesic="true"
-              visible="true"
-              fit="true"
-              static="true"
-            ></ui-gmap-polyline>
-            <ui-gmap-marker
-              ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-              coords="monitoringDetailController.map.poi"
-              idKey="'coords'"
-            ></ui-gmap-marker>
-          </ui-gmap-google-map>
-        </div>
-      </div>
-    </div>
+    <div class="col-md-8 col-lg-7" ng-include="'/views/monitorings/geolocation.html'"></div>
 
     <div class="col-md-4 col-lg-5">
       <div class="row">

--- a/client/views/monitorings/mammals.html
+++ b/client/views/monitorings/mammals.html
@@ -20,50 +20,7 @@
   <div ng-include="'/views/monitorings/common.html'"></div>
 
   <div class="row">
-    <div class="col-md-8 col-lg-7">
-      <div class="row">
-        <div class="col-md-6">
-          <field name="latitude" type="float" required="true"
-                 label="{{'MAMMALS_DETAIL_LATITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.latitude"></field>
-        </div>
-        <div class="col-md-6">
-          <field name="longitude" type="float" required="true"
-                 label="{{'MAMMALS_DETAIL_LONGITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.longitude"></field>
-        </div>
-        <div class="col-md-12">
-          <div class="text-right">
-            <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
-          </div>
-          <ui-gmap-google-map
-            center="monitoringDetailController.map.center"
-            pan="true"
-            zoom="monitoringDetailController.map.zoom"
-            events="{click: monitoringDetailController.map.click}"
-            options="{mapTypeId: 'hybrid', clickableIcons: false}">
-            <ui-gmap-polyline
-              ng-if="monitoringDetailController.track.length"
-              path="monitoringDetailController.track"
-              stroke="{color: '#36c', weight: 3}"
-              editable="false"
-              draggable="false"
-              geodesic="true"
-              visible="true"
-              fit="true"
-              static="true"
-            ></ui-gmap-polyline>
-            <ui-gmap-marker
-              ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-              coords="monitoringDetailController.map.poi"
-              idKey="'coords'"
-            ></ui-gmap-marker>
-          </ui-gmap-google-map>
-        </div>
-      </div>
-    </div>
+    <div class="col-md-8 col-lg-7" ng-include="'/views/monitorings/geolocation.html'"></div>
 
     <div class="col-md-4 col-lg-5">
       <div class="row">

--- a/client/views/monitorings/plants.html
+++ b/client/views/monitorings/plants.html
@@ -20,50 +20,7 @@
   <div ng-include="'/views/monitorings/common.html'"></div>
 
   <div class="row">
-    <div class="col-md-7 col-lg-6">
-      <div class="row">
-        <div class="col-md-6">
-          <field name="latitude" type="float" required="true"
-                 label="{{'PLANTS_DETAIL_LATITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.latitude"></field>
-        </div>
-        <div class="col-md-6">
-          <field name="longitude" type="float" required="true"
-                 label="{{'PLANTS_DETAIL_LONGITUDE' | translate}}"
-                 on-select="monitoringDetailController.updateFromModel()"
-                 model="monitoringDetailController.data.longitude"></field>
-        </div>
-        <div class="col-md-12">
-          <div class="text-right">
-            <track-edit ng-model="monitoringDetailController.data.track"></track-edit>
-          </div>
-          <ui-gmap-google-map
-            center="monitoringDetailController.map.center"
-            pan="true"
-            zoom="monitoringDetailController.map.zoom"
-            events="{click: monitoringDetailController.map.click}"
-            options="{mapTypeId: 'hybrid', clickableIcons: false}">
-            <ui-gmap-polyline
-              ng-if="monitoringDetailController.track.length"
-              path="monitoringDetailController.track"
-              stroke="{color: '#36c', weight: 3}"
-              editable="false"
-              draggable="false"
-              geodesic="true"
-              visible="true"
-              fit="true"
-              static="true"
-            ></ui-gmap-polyline>
-            <ui-gmap-marker
-              ng-if="monitoringDetailController.map.poi.latitude && monitoringDetailController.map.poi.longitude"
-              coords="monitoringDetailController.map.poi"
-              idKey="'coords'"
-            ></ui-gmap-marker>
-          </ui-gmap-google-map>
-        </div>
-      </div>
-    </div>
+    <div class="col-md-7 col-lg-6" ng-include="'/views/monitorings/geolocation.html'"></div>
 
     <div class="col-md-5 col-lg-6">
       <div class="row">

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -934,5 +934,7 @@
     "LIST_FILTER_GEOLOCATION": "Геолокация",
     "LIST_FILTER_GEOLOCATION_PLACEHOLDER": "Изберете геолокация",
     "LIST_FILTER_GEOLOCATION_BTN_CLEAR_LABEL": "Изчисти",
-    "NO_CONNECTION_WITH_SERVER": "Няма връзка със сървъра."
+    "NO_CONNECTION_WITH_SERVER": "Няма връзка със сървъра.",
+    "DETAIL_LATITUDE": "Географска ширина",
+    "DETAIL_LONGITUDE": "Географска дължина"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -934,5 +934,7 @@
     "LIST_FILTER_GEOLOCATION": "Geolocation",
     "LIST_FILTER_GEOLOCATION_PLACEHOLDER": "Select geolocation",
     "LIST_FILTER_GEOLOCATION_BTN_CLEAR_LABEL": "Clear",
-    "NO_CONNECTION_WITH_SERVER": "No connection with server."
+    "NO_CONNECTION_WITH_SERVER": "No connection with server.",
+    "DETAIL_LATITUDE": "Latitude",
+    "DETAIL_LONGITUDE": "Longitude"
 }


### PR DESCRIPTION
Latitude and longitude fields have button to fill with current location. If user have already granted permission to access location, on new record it is populated with current location.

As a side effect both fields share common term `DETAIL_LATITUDE` and `DETAIL_LONGITUDE`. The old `${FORM}_DETAIL_LATITUDE` and `${FORM}_DETAIL_LONGITUDE` are no longer used.

![Screenshot from 2019-05-02 10-28-45](https://user-images.githubusercontent.com/185580/57061321-13ea7380-6cc5-11e9-9d6e-e8701f39c8c6.png)

To test - login to [staging](https://smartbirds-staging.herokuapp.com/) and start new form record.