### PR TITLE
Fill observationDateTime with current timestamp on new record

### DIFF
--- a/client/scripts/controllers/MonitoringDetailController.js
+++ b/client/scripts/controllers/MonitoringDetailController.js
@@ -28,6 +28,8 @@ require('../app').controller('MonitoringDetailController', /* @ngInject */functi
   } else {
     controller.data = new model() // eslint-disable-line new-cap
     controller.data.observationDateTime = new Date()
+    controller.data.startDateTime = controller.data.observationDateTime
+    controller.data.endDateTime = controller.data.observationDateTime
     if (angular.isFunction(model.prototype.afterCreate)) { model.prototype.afterCreate.apply(controller.data) }
     checkCanSave()
   }

--- a/client/scripts/controllers/MonitoringDetailController.js
+++ b/client/scripts/controllers/MonitoringDetailController.js
@@ -27,6 +27,7 @@ require('../app').controller('MonitoringDetailController', /* @ngInject */functi
     controller.data = model.get({ id: id })
   } else {
     controller.data = new model() // eslint-disable-line new-cap
+    controller.data.observationDateTime = new Date()
     if (angular.isFunction(model.prototype.afterCreate)) { model.prototype.afterCreate.apply(controller.data) }
     checkCanSave()
   }


### PR DESCRIPTION
When creating new record the observation date and time are prefilled with current time and date. If necessary user can still change them.