### PR TITLE
Use nomenclatures EN label as key in db service

### DIFF
--- a/client/scripts/directives/field.js
+++ b/client/scripts/directives/field.js
@@ -146,12 +146,12 @@ require('../app').directive('field', /* @ngInject */function ($q, Raven, geoloca
               if (angular.isArray(field.model)) {
                 field.model.forEach(function (item, idx, array) {
                   if (angular.isObject(item) && !(item instanceof Species)) {
-                    array[idx] = db.species[field.nomenclature][item.label.bg] || new Species(item)
+                    array[idx] = db.species[field.nomenclature][item.label.en] || new Species(item)
                   }
                 })
               } else if (angular.isObject(field.model)) {
                 if (!(field.model instanceof Species)) {
-                  field.model = db.species[field.nomenclature][field.model.label.bg] || new Species(field.model)
+                  field.model = db.species[field.nomenclature][field.model.label.en] || new Species(field.model)
                 }
               }
             }
@@ -185,12 +185,12 @@ require('../app').directive('field', /* @ngInject */function ($q, Raven, geoloca
               if (angular.isArray(field.model)) {
                 field.model.forEach(function (item, idx, array) {
                   if (angular.isObject(item) && !(item instanceof Nomenclature)) {
-                    array[idx] = db.nomenclatures[field.nomenclature][item.label.bg] || new Nomenclature(item)
+                    array[idx] = db.nomenclatures[field.nomenclature][item.label.en] || new Nomenclature(item)
                   }
                 })
               } else if (angular.isObject(field.model)) {
                 if (!(field.model instanceof Nomenclature)) {
-                  field.model = db.nomenclatures[field.nomenclature][field.model.label.bg] || new Nomenclature(field.model)
+                  field.model = db.nomenclatures[field.nomenclature][field.model.label.en] || new Nomenclature(field.model)
                 }
               }
             }

--- a/client/scripts/services/db.js
+++ b/client/scripts/services/db.js
@@ -39,7 +39,7 @@ require('../app').service('db', /* @ngInject */function ($q, Location, Nomenclat
         var res = db.nomenclatures
         items.forEach(function (item) {
           res[ item.type ] = res[ item.type ] || {}
-          res[ item.type ][ item.label.bg ] = item
+          res[ item.type ][ item.label.en ] = item
         })
         return res
       })


### PR DESCRIPTION
Refactor db service to index nomenclatures with EN labels instead BG. 
EN label and nomenclature type will be used as identifier in the future 