### PR TITLE
Include fields for balkan threats db in export

### DIFF
--- a/server/forms/threats.js
+++ b/server/forms/threats.js
@@ -254,7 +254,7 @@ exports.prepareCsv = async function (api, record, csv) {
         ...csv,
         categoryThreatsBG: record.categoryBg,
         categoryThreatsEN: record.categoryEn,
-        speciesThreats: record.speciesInfo.labelLa,
+        speciesThreats: record.speciesInfo && record.speciesInfo.labelLa,
         countThreats: record.count,
         estimateThreatsBG: record.estimateBg,
         estimateThreatsEN: record.estimateEn

--- a/server/forms/threats.js
+++ b/server/forms/threats.js
@@ -194,3 +194,74 @@ exports.validate = {
     }
   }
 }
+
+exports.prepareCsv = async function (api, record, csv) {
+  // define all used fields, so the first record can output proper header
+  csv = {
+    ...csv,
+    id: record.id,
+    categoryThreatsBG: '',
+    categoryThreatsEN: '',
+    speciesThreats: '',
+    countThreats: '',
+    estimateThreatsBG: '',
+    estimateThreatsEN: '',
+    deadSpecies: '',
+    deadSpeciesCount: '',
+    aliveAnimal: 'N',
+    aliveAnimalCount: '',
+    poisonBaits: 'N',
+    poisonBaitsCount: ''
+  }
+  switch (record.primaryType) {
+    case formsConfig.threatsPrimaryTypes.poison.id:
+      csv = {
+        ...csv,
+        categoryThreatsBG: 'Тровене',
+        categoryThreatsEN: 'Poisoning'
+      }
+
+      switch (record.poisonedType) {
+        case formsConfig.threatsPoisonedType.alive.id:
+          csv = {
+            ...csv,
+            aliveAnimal: 'Y',
+            aliveAnimalCount: record.count
+          }
+          break
+        case formsConfig.threatsPoisonedType.bait.id:
+          csv = {
+            ...csv,
+            poisonBaits: 'Y',
+            poisonBaitsCount: record.count
+          }
+          break
+        case formsConfig.threatsPoisonedType.dead.id:
+          csv = {
+            ...csv,
+            aliveAnimal: 'N',
+            deadSpecies: record.speciesInfo.labelLa,
+            deadSpeciesCount: record.count
+          }
+          break
+        default:
+          throw new Error('Unsupported poisoned type: ' + record.poisonedType)
+      }
+
+      break
+    case formsConfig.threatsPrimaryTypes.threat.id:
+      csv = {
+        ...csv,
+        categoryThreatsBG: record.categoryBg,
+        categoryThreatsEN: record.categoryEn,
+        speciesThreats: record.speciesInfo.labelLa,
+        countThreats: record.count,
+        estimateThreatsBG: record.estimateBg,
+        estimateThreatsEN: record.estimateEn
+      }
+      break
+    default:
+      throw new Error('Unsupported primary type: ' + record.primaryType)
+  }
+  return csv
+}

--- a/server/initializers/forms.js
+++ b/server/initializers/forms.js
@@ -255,13 +255,11 @@ function generateExportData (form) {
       pre.firstName = this.user.firstName
       pre.lastName = this.user.lastName
     }
-    let mid = {}
+    let mid = _.omitBy(this.dataValues, function (value, key) {
+      return form.exportSkipFields.indexOf(key.split('.')[ 0 ]) !== -1
+    })
     if (form.prepareCsv) {
-      mid = await form.prepareCsv(api, this)
-    } else {
-      mid = _.omitBy(this.dataValues, function (value, key) {
-        return form.exportSkipFields.indexOf(key.split('.')[ 0 ]) !== -1
-      })
+      mid = await form.prepareCsv(api, this, mid)
     }
     const post = {
       notes: (this.notes || '').replace(/[\n\r]+/g, ' '),


### PR DESCRIPTION
Uses the existing export, and adds the additional fields by resolving the primary type and poison type.

TODO: use i18n files to get localized labels for poison category type.

Pending validation from @GPopgeorgiev for the format.