### PR TITLE
Support empty value in config-label

### DIFF
--- a/client/scripts/directives/configLabel.js
+++ b/client/scripts/directives/configLabel.js
@@ -17,7 +17,20 @@ require('../app').directive('configLabel', /* @ngInject */function () {
         throw new Error('Unsupported config type: "' + $attrs.config + '"\nAvailable values are: ' + Object.keys(formsConfig).join(', '))
       }
 
-      $translate(formsConfig[$attrs.config][$scope.value].label).then(function (val) { $ctrl.label = val }).catch(angular.noop)
+      // if not selected, display nothing
+      if (!$scope.value) {
+        $ctrl.label = ''
+        return
+      }
+
+      var currentValue = formsConfig[$attrs.config][$scope.value]
+
+      // validate config has label
+      if (!('label' in currentValue)) {
+        throw new Error('formsConfig[' + $attrs.config + '][' + $scope.value + '] is missing label key')
+      }
+
+      $translate(currentValue.label).then(function (val) { $ctrl.label = val }).catch(angular.noop)
       $ctrl.label = $translate.instant(formsConfig[$attrs.config][$scope.value].label)
     },
     controllerAs: '$ctrl'


### PR DESCRIPTION
In case the value is not set instead of crashing it's better to render empty string.

Also added validation that configuration has label.