### PR TITLE
Fix migration on tests

### DIFF
--- a/server/migrations/20200122114937-add-organization-relation.js
+++ b/server/migrations/20200122114937-add-organization-relation.js
@@ -3,7 +3,11 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.addColumn('Users', 'organizationSlug', { type: Sequelize.TEXT, defaultValue: 'bspb', allowNull: false })
-    await queryInterface.sequelize.query('ALTER TABLE "Users" ALTER COLUMN "organizationSlug" DROP DEFAULT;')
+
+    // sqlite cannot drop default, and it's for tests, so no harm
+    if (queryInterface.sequelize.options.dialect !== 'sqlite') {
+      await queryInterface.sequelize.query('ALTER TABLE "Users" ALTER COLUMN "organizationSlug" DROP DEFAULT;')
+    }
   },
 
   down: async (queryInterface, Sequelize) => {


### PR DESCRIPTION
A migration tries to drop default on a column, but that fails in sqlite. In this particular case it's safe to skip it.