### PR TITLE
Properly handle failed auto migrations

### DIFF
--- a/server/initializers/sequelize.js
+++ b/server/initializers/sequelize.js
@@ -192,7 +192,11 @@ module.exports = upgradeInitializer('ah17', {
         return next(err)
       }
 
-      api.sequelize.autoMigrate(function () {
+      api.sequelize.autoMigrate(function (err) {
+        if (err) {
+          console.error(err)
+          return next(err)
+        }
         api.sequelize.loadFixtures(next)
       })
     })


### PR DESCRIPTION
A migration error was masked and did not actually result in error.