### PR TITLE
Set english as default language for newly created users

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -55,7 +55,7 @@ module.exports = function (sequelize, DataTypes) {
     },
     language: {
       type: DataTypes.STRING,
-      defaultValue: 'bg'
+      defaultValue: 'en'
     },
     forgotPasswordHash: DataTypes.TEXT,
     forgotPasswordTimestamp: DataTypes.DATE,


### PR DESCRIPTION
With the addition of international users it's better to have the english as default.