### PR TITLE
Add organization to every form record and allow filtering by it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pids/
 public/css/main.css*
 uploads/
 public/*_stats.json
+public/organizations.json

--- a/server/forms/_common.js
+++ b/server/forms/_common.js
@@ -90,6 +90,14 @@ exports.fields = {
       model: 'user'
     }
   },
+  organization: {
+    type: 'choice',
+    required: true,
+    relation: {
+      model: 'organization'
+    },
+    default: 'bspb'
+  },
   createdAt: {
     type: 'timestamp',
     required: true
@@ -106,7 +114,8 @@ exports.foreignKeys = [
 ]
 
 exports.indexes = [
-  { fields: ['userId'] }
+  { fields: ['userId'] },
+  { fields: ['organization'] }
 ]
 
 exports.exportSkipFields = [

--- a/server/forms/cbm.js
+++ b/server/forms/cbm.js
@@ -164,6 +164,15 @@ exports.fields = {
     }
   },
 
+  organization: {
+    type: 'choice',
+    required: true,
+    relation: {
+      model: 'organization'
+    },
+    default: 'bspb'
+  },
+
   pictures: 'json',
   track: 'text'
 }

--- a/server/initializers/formActions.js
+++ b/server/initializers/formActions.js
@@ -13,6 +13,7 @@ function generateInsertAction (form) {
       if ((!data.session.user.isAdmin && !api.forms.isModerator(data.session.user, form.modelName)) || !data.params.user) {
         data.params.user = data.session.userId
       }
+      data.params.organization = data.session.user.organizationSlug
       record = await record.apiUpdate(data.params, data.session.user.language)
       const hash = record.calculateHash()
       api.log('looking for %s with hash %s', 'info', form.modelName, hash)
@@ -160,6 +161,7 @@ function generateFormActions (form) {
   }
   const listInputs = _.extend({
     user: {},
+    organization: {},
     limit: { default: 20 },
     offset: { default: 0 },
     location: {},
@@ -193,6 +195,7 @@ function generateFormActions (form) {
 
   _.forEach(form.fields, (field, fieldName) => {
     if (fieldName === 'createdAt' || fieldName === 'updatedAt') return
+    if (fieldName === 'organization') return
     if (field.private) return
     insertInputs[fieldName] = {
       required: field.required && fieldName !== 'user'

--- a/server/initializers/formMethods.js
+++ b/server/initializers/formMethods.js
@@ -116,6 +116,12 @@ function generatePrepareQuery (form) {
           userId: data.params.user
         })
       }
+
+      if (data.params.organization) {
+        query.where = _.extend(query.where || {}, {
+          organization: data.params.organization
+        })
+      }
     } else if (data.session.user.isAdmin || api.forms.isModerator(data.session.user, form.modelName)) {
       if (data.params.user) {
         query.where = _.extend(query.where || {}, {

--- a/server/initializers/forms.js
+++ b/server/initializers/forms.js
@@ -47,6 +47,10 @@ function formAttributes (fields) {
       allowNull: !field.required
     }
 
+    if (field.default) {
+      fd.defaultValue = field.default
+    }
+
     switch (field.type) {
       case 'multi':
       case 'choice': {
@@ -55,6 +59,7 @@ function formAttributes (fields) {
             Object.assign(fieldsDef, localField(name, { required: field.required }).attributes)
             break
           }
+          case 'organization':
           case 'species': {
             fieldsDef[name] = _.extend({
               type: DataTypes.TEXT
@@ -195,6 +200,7 @@ function generateApiData (fields) {
                 }
                 return res
               }
+              case 'organization':
               case 'species': {
                 return this[name] ? this[name].split('|').map(function (val) {
                   return val.trim()
@@ -214,6 +220,7 @@ function generateApiData (fields) {
                   return null
                 }
               }
+              case 'organization':
               case 'species': {
                 return this[name]
               }
@@ -332,6 +339,7 @@ function generateApiUpdate (fields) {
               }
               break
             }
+            case 'organization':
             case 'species': {
               if (!_.has(data, name)) return
 
@@ -358,6 +366,7 @@ function generateApiUpdate (fields) {
               localField(name).update(this, data[name] != null ? data[name].label : null, language)
               break
             }
+            case 'organization':
             case 'species': {
               if (!_.has(data, name)) return
 

--- a/server/migrations/20200420123303-add-forms-organization-field.js
+++ b/server/migrations/20200420123303-add-forms-organization-field.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const tables = [
+  'FormBirds',
+  'FormCBM',
+  'FormCiconia',
+  'FormHerptiles',
+  'FormInvertebrates',
+  'FormMammals',
+  'FormPlants',
+  'FormThreats'
+]
+
+module.exports = {
+  up: async function (queryInterface, Sequelize) {
+    await Promise.all(tables.map(async (table) => {
+      await queryInterface.addColumn(table, 'organization', { type: Sequelize.TEXT, allowNull: false, defaultValue: 'bspb' })
+      await queryInterface.addIndex(table, { fields: ['organization'] })
+    }))
+  },
+
+  down: async function (queryInterface, Sequelize) {
+    await Promise.all(tables.map(async (table) => {
+      await queryInterface.removeColumn(table, 'organization')
+    }))
+  }
+}

--- a/test/actions/organizations.js
+++ b/test/actions/organizations.js
@@ -1,0 +1,66 @@
+/* global describe, before, after, it */
+
+const should = require('should')
+const setup = require('../_setup')
+const generators = require('../helpers/generators')
+
+const forms = [
+  'formBirds',
+  'formCBM',
+  'formCiconia',
+  'formHerptiles',
+  'formInvertebrates',
+  'formMammals',
+  'formPlants',
+  'formThreats'
+]
+
+describe('Organizations', () => {
+  let user
+
+  before(async () => {
+    await setup.init()
+    user = await setup.api.models.user.findOne({ where: { email: 'user2@smartbirds.com' } })
+
+    user.should.have.property('organizationSlug', 'independent')
+  })
+
+  after(async () => {
+    await setup.finish()
+  })
+
+  forms.forEach((form) => {
+    describe(form, () => {
+      it('attaches the user\'s organization when creating record', async () => {
+        const record = await setup.api.models[form].build(generators[form]()).apiData()
+        const response = await setup.runActionAsUser2(`${form}:create`, record)
+        should.not.exist(response.error)
+        response.data.organization.should.be.equal('independent')
+      })
+
+      it('keeps the initial organization when updating record', async () => {
+        const record = await setup.api.models[form].create(generators[form]({
+          userId: user.id,
+          organization: 'some'
+        }))
+        const request = await record.apiData(setup.api)
+        delete request.organization
+        const response = await setup.runActionAsUser2(`${form}:edit`, request)
+        should.not.exist(response.error)
+        response.data.organization.should.be.equal('some')
+      })
+
+      it('does not allow updating organization when updating record', async () => {
+        const record = await setup.api.models[form].create(generators[form]({
+          userId: user.id,
+          organization: 'some'
+        }))
+        const request = await record.apiData(setup.api)
+        request.organization = 'other'
+        const response = await setup.runActionAsUser2(`${form}:edit`, request)
+        should.not.exist(response.error)
+        response.data.organization.should.be.equal('some')
+      })
+    })
+  })
+})

--- a/test/fixtures/02-users.js
+++ b/test/fixtures/02-users.js
@@ -36,7 +36,7 @@ module.exports = [
       role: 'user',
       passwordHash: '$2a$10$32SyvkdyXJNRRAX8PBMHq.cyHDI19vdle/v6zeDhn7SxhgAYyFucC', // hash of 'secret'
       gdprConsent: true,
-      organizationSlug: 'bspb'
+      organizationSlug: 'independent'
     }
   },
   {


### PR DESCRIPTION
Organization is automatically populated on creation with the user's current organization. On record update the initial organization is kept unchanged (as requested).