### PR TITLE
feat(bgatlas): user selected bg atlas cells in auth restore

### DIFF
--- a/__tests__/actions/session.js
+++ b/__tests__/actions/session.js
@@ -66,7 +66,10 @@ describe('Action session', () => {
         user: expect.objectContaining({
           bgatlasCells: [expect.objectContaining({
             utm_code: cell.utm_code,
-            coordinates: cell.coordinates()
+            coordinates: cell.coordinates(),
+            spec_known: expect.any(Number),
+            spec_unknown: expect.any(Number),
+            spec_old: expect.any(Number)
           })]
         })
       }))
@@ -114,7 +117,10 @@ describe('Action session', () => {
         user: expect.objectContaining({
           bgatlasCells: [expect.objectContaining({
             utm_code: cell.utm_code,
-            coordinates: cell.coordinates()
+            coordinates: cell.coordinates(),
+            spec_known: expect.any(Number),
+            spec_unknown: expect.any(Number),
+            spec_old: expect.any(Number)
           })]
         })
       }))

--- a/__tests__/models/user.js
+++ b/__tests__/models/user.js
@@ -26,10 +26,28 @@ describe('user model', () => {
     await user.setBgatlas2008Cells([cell.utm_code])
 
     const saved = await user.getBgatlas2008Cells()
-    expect(saved).toEqual([expect.objectContaining(cellData)])
+    expect(saved).toEqual([expect.objectContaining({
+      utm_code: cellData.utm_code,
+      spec_old: expect.any(Number),
+      spec_known: expect.any(Number),
+      spec_unknown: expect.any(Number)
+    })])
   })
 
-  it('can load with bgatlas2008 cells', async () => {
+  it('can set bgatlas2008 cells and load cells', async () => {
+    await user.setBgatlas2008Cells([cell.utm_code])
+
+    const saved = await user.getBgatlas2008Cells({ include: ['utmCoordinates'] })
+    expect(saved).toEqual([expect.objectContaining({
+      utm_code: cellData.utm_code,
+      utmCoordinates: expect.objectContaining(cellData),
+      spec_old: expect.any(Number),
+      spec_known: expect.any(Number),
+      spec_unknown: expect.any(Number)
+    })])
+  })
+
+  it('can load with bgatlas2008 stats cells', async () => {
     await user.setBgatlas2008Cells([cell.utm_code])
 
     const loadedUser = await api.models.user.findOne({
@@ -37,6 +55,27 @@ describe('user model', () => {
       include: [api.models.user.associations.bgatlas2008Cells]
     })
 
-    expect(loadedUser.bgatlas2008Cells).toEqual([expect.objectContaining(cellData)])
+    expect(loadedUser.bgatlas2008Cells).toEqual([expect.objectContaining({
+      utm_code: cellData.utm_code,
+      spec_old: expect.any(Number),
+      spec_known: expect.any(Number),
+      spec_unknown: expect.any(Number)
+    })])
+  })
+
+  it('can load with bgatlas2008 stats and cells', async () => {
+    await user.setBgatlas2008Cells([cell.utm_code])
+
+    const loadedUser = await api.models.user.findOne({
+      where: { id: user.id },
+      include: [{
+        association: 'bgatlas2008Cells',
+        include: 'utmCoordinates'
+      }]
+    })
+
+    expect(loadedUser.bgatlas2008Cells).toEqual([expect.objectContaining({
+      utmCoordinates: expect.objectContaining(cellData)
+    })])
   })
 })

--- a/server/actions/session.js
+++ b/server/actions/session.js
@@ -85,7 +85,11 @@ exports.sessionCreate = upgradeAction('ah17', {
           .then(async (sessionData) => {
             data.response.user = user.apiData(api)
             if (data.params.include.bgatlasCells) {
-              data.response.user.bgatlasCells = (await user.getBgatlas2008Cells()).map((cell) => cell.apiData())
+              data.response.user.bgatlasCells = (await user.getBgatlas2008Cells({
+                include: [
+                  api.models.bgatlas2008_stats_global.associations.utmCoordinates
+                ]
+              })).map((cell) => cell.apiData())
             }
             data.response.success = true
             data.response.csrfToken = sessionData.csrfToken
@@ -144,7 +148,11 @@ exports.sessionCheck = upgradeAction('ah17', {
 
         data.response.user = user.apiData(api)
         if (data.params.include.bgatlasCells) {
-          data.response.user.bgatlasCells = (await user.getBgatlas2008Cells()).map((cell) => cell.apiData())
+          data.response.user.bgatlasCells = (await user.getBgatlas2008Cells({
+            include: [
+              api.models.bgatlas2008_stats_global.associations.utmCoordinates
+            ]
+          })).map((cell) => cell.apiData())
         }
         data.response.csrfToken = sessionData.csrfToken
         data.response.success = true

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -123,7 +123,7 @@ module.exports = function (sequelize, DataTypes) {
           foreignKey: 'sharer',
           otherKey: 'sharee'
         })
-        models.user.belongsToMany(models.bgatlas2008_cells, {
+        models.user.belongsToMany(models.bgatlas2008_stats_global, {
           as: 'bgatlas2008Cells',
           through: 'bgatlas2008_user_selected',
           timestamps: false,


### PR DESCRIPTION
Similar to login `include: ['bgatlasCells']` list parameter
will include in the `response.user.bgatlasCells`
the selected cells with their coordinates