### PR TITLE
feat(bgatlas): export atlas global stats

### DIFF
--- a/__tests__/tasks/statistics.js
+++ b/__tests__/tasks/statistics.js
@@ -29,7 +29,7 @@ describe('Statistics task', function () {
       const result = await runLocal()
 
       expect(result).toEqual(expect.arrayContaining([
-        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 0, spec_old: 0 }
+        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 0, spec_old: 0, coordinates: cell.coordinates() }
       ]))
     })
 
@@ -40,7 +40,7 @@ describe('Statistics task', function () {
       const result = await runLocal()
 
       expect(result).toEqual(expect.arrayContaining([
-        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 0, spec_old: 1 }
+        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 0, spec_old: 1, coordinates: cell.coordinates() }
       ]))
     })
 
@@ -54,7 +54,7 @@ describe('Statistics task', function () {
       const result = await runLocal()
 
       expect(result).toEqual(expect.arrayContaining([
-        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 1, spec_old: 0 }
+        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 1, spec_old: 0, coordinates: cell.coordinates() }
       ]))
     })
 
@@ -71,7 +71,7 @@ describe('Statistics task', function () {
       const result = await runLocal()
 
       expect(result).toEqual(expect.arrayContaining([
-        { utm_code: cell.utm_code, spec_known: 1, spec_unknown: 0, spec_old: 1 }
+        { utm_code: cell.utm_code, spec_known: 1, spec_unknown: 0, spec_old: 1, coordinates: cell.coordinates() }
       ]))
     })
   })

--- a/__tests__/tasks/statistics.js
+++ b/__tests__/tasks/statistics.js
@@ -1,0 +1,78 @@
+/* eslint-env node, jest */
+/* globals setup */
+
+const { promisify } = require('util')
+const readFile = promisify(require('fs').readFile)
+
+const bgatlas2008CellsFactory = require('../../__utils__/factories/bgatlas2008CellsFactory')
+const bgatlas2008SpeciesFactory = require('../../__utils__/factories/bgatlas2008SpeciesFactory')
+const formBirdsFactory = require('../../__utils__/factories/formBirdsFactory')
+const speciesFactory = require('../../__utils__/factories/speciesFactory')
+
+const run = () => setup.api.tasks.tasks['stats:generate'].run()
+const readStatFile = async (name) => {
+  const content = await readFile(setup.api.config.general.paths.public[0] + '/' + name + '.json')
+  return JSON.parse(content)
+}
+
+describe('Statistics task', function () {
+  describe('bgatlas2008_stats_global', () => {
+    const runLocal = async () => {
+      await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: 'formBirds' })
+      await setup.api.tasks.tasks.bgatlas2008_refresh.run()
+      await run()
+      return readStatFile('bgatlas2008_stats_global')
+    }
+
+    it('includes cell outside atlas without observation', async () => {
+      const cell = await bgatlas2008CellsFactory(setup.api)
+      const result = await runLocal()
+
+      expect(result).toEqual(expect.arrayContaining([
+        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 0, spec_old: 0 }
+      ]))
+    })
+
+    it('includes cell from atlas without observation', async () => {
+      const cell = await bgatlas2008CellsFactory(setup.api)
+      await bgatlas2008SpeciesFactory(setup.api, cell)
+
+      const result = await runLocal()
+
+      expect(result).toEqual(expect.arrayContaining([
+        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 0, spec_old: 1 }
+      ]))
+    })
+
+    it('includes cell outside atlas with observation', async () => {
+      const cell = await bgatlas2008CellsFactory(setup.api)
+      await formBirdsFactory(setup.api, {
+        latitude: (cell.lat1 + cell.lat2 + cell.lat3 + cell.lat4) / 4,
+        longitude: (cell.lon1 + cell.lon2 + cell.lon3 + cell.lon4) / 4
+      })
+
+      const result = await runLocal()
+
+      expect(result).toEqual(expect.arrayContaining([
+        { utm_code: cell.utm_code, spec_known: 0, spec_unknown: 1, spec_old: 0 }
+      ]))
+    })
+
+    it('includes cell from atlas with observation', async () => {
+      const cell = await bgatlas2008CellsFactory(setup.api)
+      const species = await speciesFactory(setup.api)
+      await bgatlas2008SpeciesFactory(setup.api, cell, species)
+      await formBirdsFactory(setup.api, {
+        species,
+        latitude: (cell.lat1 + cell.lat2 + cell.lat3 + cell.lat4) / 4,
+        longitude: (cell.lon1 + cell.lon2 + cell.lon3 + cell.lon4) / 4
+      })
+
+      const result = await runLocal()
+
+      expect(result).toEqual(expect.arrayContaining([
+        { utm_code: cell.utm_code, spec_known: 1, spec_unknown: 0, spec_old: 1 }
+      ]))
+    })
+  })
+})

--- a/__tests__/tasks/statistics.js
+++ b/__tests__/tasks/statistics.js
@@ -21,7 +21,7 @@ describe('Statistics task', function () {
       await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: 'formBirds' })
       await setup.api.tasks.tasks.bgatlas2008_refresh.run()
       await run()
-      return readStatFile('bgatlas2008_stats_global')
+      return readStatFile('bgatlas2008_global_stats')
     }
 
     it('includes cell outside atlas without observation', async () => {

--- a/server/tasks/statistics.js
+++ b/server/tasks/statistics.js
@@ -135,7 +135,11 @@ module.exports.generateStatistics = upgradeTask('ah17', {
             }).then(records => records.map(r => r.apiData(api)))
           })
         })).reduce((a, b) => ({ ...a, ...b }))),
-        bgatlas2008_global_stats: api.models.bgatlas2008_stats_global.findAll().map((r) => r.apiData())
+        bgatlas2008_global_stats: api.models.bgatlas2008_stats_global.findAll({
+          include: [
+            api.models.bgatlas2008_stats_global.associations.utmCoordinates
+          ]
+        }).map((r) => r.apiData())
       })
 
       await Promise.props(_.mapValues(stats, function (stat, name) {

--- a/server/tasks/statistics.js
+++ b/server/tasks/statistics.js
@@ -135,7 +135,7 @@ module.exports.generateStatistics = upgradeTask('ah17', {
             }).then(records => records.map(r => r.apiData(api)))
           })
         })).reduce((a, b) => ({ ...a, ...b }))),
-        bgatlas2008_stats_global: api.models.bgatlas2008_stats_global.findAll().map((r) => r.apiData())
+        bgatlas2008_global_stats: api.models.bgatlas2008_stats_global.findAll().map((r) => r.apiData())
       })
 
       await Promise.props(_.mapValues(stats, function (stat, name) {

--- a/server/tasks/statistics.js
+++ b/server/tasks/statistics.js
@@ -58,7 +58,7 @@ module.exports.generateStatistics = upgradeTask('ah17', {
           }),
         user_rank_stats: api.models.user_rank_stats.findAll({})
           .then(records => {
-            return records.map(r => r.apiData(api)).reduce((result, current) => ({ ...result, ...current }))
+            return records.map(r => r.apiData(api)).reduce((result, current) => ({ ...result, ...current }), {})
           }),
         total_user_records_stats: api.models.total_users_records_year.findAll({
           limit: 10,
@@ -134,7 +134,8 @@ module.exports.generateStatistics = upgradeTask('ah17', {
               limit: 20
             }).then(records => records.map(r => r.apiData(api)))
           })
-        })).reduce((a, b) => ({ ...a, ...b })))
+        })).reduce((a, b) => ({ ...a, ...b }))),
+        bgatlas2008_stats_global: api.models.bgatlas2008_stats_global.findAll().map((r) => r.apiData())
       })
 
       await Promise.props(_.mapValues(stats, function (stat, name) {

--- a/server/utils/capitalizeFirstLetter.js
+++ b/server/utils/capitalizeFirstLetter.js
@@ -1,3 +1,4 @@
 module.exports = function capitalizeFirstLetter (string) {
+  if (string == null) return ''
   return string.charAt(0).toUpperCase() + string.slice(1)
 }


### PR DESCRIPTION
Export global atlas cell stats for use in public pages.

Exported stats is `bgatlas2008_global_stats.json`