### PR TITLE
feat(bgatlas): return cell info for user

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -82,6 +82,7 @@ exports.default = {
         { path: '/organization', action: 'organization:list' },
 
         { path: '/bgatlas/2008', action: 'bgatlas2008_cells_list' },
+        { path: '/bgatlas/cell/:utm_code', action: 'bgatlas2008_cell_info' },
         { path: '/bgatlas/user/selected', action: 'bgatlas2008_get_user_selection' }
       ],
 

--- a/server/models/bgatlas2008_observed_user_species.js
+++ b/server/models/bgatlas2008_observed_user_species.js
@@ -1,0 +1,13 @@
+module.exports = function (sequelize, Sequelize) {
+  return sequelize.define('bgatlas2008_observed_user_species', {
+    utm_code: { type: Sequelize.STRING(4), primaryKey: true },
+    user_id: { type: Sequelize.INTEGER, primaryKey: true },
+    species: { type: Sequelize.STRING, primaryKey: true },
+    count: { type: Sequelize.INTEGER, allowNull: true },
+    existing: { type: Sequelize.BOOLEAN, allowNull: true }
+  }, {
+    tableName: 'bgatlas2008_observed_user_species',
+    timestamps: false,
+    underscored: true
+  })
+}

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -15,7 +15,19 @@ const setup = {
     return setup.api
   },
   finish: () => setup.server.stop(),
-  runAction: (action, params) => setup.api.specHelper.runAction(action, params),
+  runAction: async (action, params) => {
+    let connection
+    if (!params) { params = {} }
+    if (params.id && params.type === 'testServer') {
+      connection = params
+    } else {
+      connection = await setup.api.specHelper.Connection.createAsync()
+      connection.params = params
+    }
+    const actionResponse = await setup.api.specHelper.runAction(action, connection)
+    actionResponse.responseHttpCode = connection.rawConnection.responseHttpCode
+    return actionResponse
+  },
   runActionAs: async (action, params, user) => {
     const conn = await setup.api.specHelper.Connection.createAsync()
     conn.params = {


### PR DESCRIPTION
A new endpoint `/bgatlas/cell/:utm_code` that returns a list of `[{ species: String, known: Boolean, observed: Boolean}]` where:
* `known` is true if species is observed in bgatlas2008 for that cell
* `observed` is true if user have observed the species in that cell

closes #496