### PR TITLE
Add atlas moderator functionality

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -85,7 +85,8 @@ exports.default = {
         { path: '/bgatlas/cell/:utm_code', action: 'bgatlas2008_cell_info' },
         { path: '/bgatlas/cell/:utm_code/stats', action: 'bgatlas2008_cell_stats' },
         { path: '/bgatlas/user/selected', action: 'bgatlas2008_get_user_selection' },
-        { path: '/bgatlas/stats/user_rank', action: 'bgatlas2008_user_rank_stats' }
+        { path: '/bgatlas/stats/user_rank', action: 'bgatlas2008_user_rank_stats' },
+        { path: '/bgatlas/moderator/:utm_code/methodology', action: 'bgatlas2008_mod_cell_methodology_stats' }
       ],
 
       post: [

--- a/server/migrations/20211030053424-alter-view-birds-observations-add-observation-methodology.js
+++ b/server/migrations/20211030053424-alter-view-birds-observations-add-observation-methodology.js
@@ -1,0 +1,65 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    if (queryInterface.sequelize.options.dialect !== 'postgres') return
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW birds_observations AS
+      SELECT
+        form_name, id,
+        latitude, longitude,
+        "userId" as user_id, organization,
+        "observationDateTime" as observation_date_time, species, count,
+        "monitoringCode" as monitoring, "startDateTime" as start_datetime, "endDateTime" as end_datetime, confidential,
+        "autoLocationEn" as auto_location_en, "autoLocationLocal" as auto_location_local, "autoLocationLang" as auto_location_lang,
+        "bgatlas2008UtmCode" as bgatlas2008_utm_code,
+        "observationMethodologyEn" as observation_methodology_en,
+        "observationMethodologyLocal" as observation_methodology_local,
+        "observationMethodologyLang" as observation_methodology_lang
+      FROM
+        (
+          SELECT
+            'FormBirds' as form_name, id,
+            latitude, longitude,
+            "userId", organization,
+            "observationDateTime", species, GREATEST(count, "countMin", "countMax") as count,
+            "monitoringCode", "startDateTime", "endDateTime", confidential,
+            "autoLocationEn", "autoLocationLocal", "autoLocationLang",
+            "observationMethodologyEn", "observationMethodologyLocal", "observationMethodologyLang",
+            "bgatlas2008UtmCode"
+          FROM "FormBirds"
+
+          UNION ALL
+
+          SELECT
+            'FormCBM' as form_name, id,
+            latitude, longitude,
+            "userId", organization,
+            "observationDateTime", species, count,
+            "monitoringCode", "startDateTime", "endDateTime", confidential,
+            "autoLocationEn", "autoLocationLocal", "autoLocationLang",
+            "observationMethodologyEn", "observationMethodologyLocal", "observationMethodologyLang",
+            "bgatlas2008UtmCode"
+          FROM "FormCBM"
+
+          UNION ALL
+
+          SELECT
+            'FormCiconia' as form_name, id,
+            latitude, longitude,
+            "userId", organization,
+            "observationDateTime", 'Ciconia ciconia' as species, NULL::integer as count,
+            "monitoringCode", "startDateTime", "endDateTime", confidential,
+            "autoLocationEn", "autoLocationLocal", "autoLocationLang",
+            "observationMethodologyEn", "observationMethodologyLocal", "observationMethodologyLang",
+            "bgatlas2008UtmCode"
+          FROM "FormCiconia"
+        ) birds_observations
+    `)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    if (queryInterface.sequelize.options.dialect !== 'postgres') return
+    await queryInterface.sequelize.query('DROP VIEW IF EXISTS birds_observations')
+  }
+}

--- a/server/migrations/20211030053424-alter-view-birds-observations-add-observation-methodology.js
+++ b/server/migrations/20211030053424-alter-view-birds-observations-add-observation-methodology.js
@@ -60,6 +60,52 @@ module.exports = {
 
   down: async (queryInterface, Sequelize) => {
     if (queryInterface.sequelize.options.dialect !== 'postgres') return
-    await queryInterface.sequelize.query('DROP VIEW IF EXISTS birds_observations')
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW birds_observations AS
+      SELECT
+        form_name, id,
+        latitude, longitude,
+        "userId" as user_id, organization,
+        "observationDateTime" as observation_date_time, species, count,
+        "monitoringCode" as monitoring, "startDateTime" as start_datetime, "endDateTime" as end_datetime, confidential,
+        "autoLocationEn" as auto_location_en, "autoLocationLocal" as auto_location_local, "autoLocationLang" as auto_location_lang,
+        "bgatlas2008UtmCode" as bgatlas2008_utm_code
+      FROM
+        (
+          SELECT
+            'FormBirds' as form_name, id,
+            latitude, longitude,
+            "userId", organization,
+            "observationDateTime", species, GREATEST(count, "countMin", "countMax") as count,
+            "monitoringCode", "startDateTime", "endDateTime", confidential,
+            "autoLocationEn", "autoLocationLocal", "autoLocationLang",
+            "bgatlas2008UtmCode"
+          FROM "FormBirds"
+
+          UNION ALL
+
+          SELECT
+            'FormCBM' as form_name, id,
+            latitude, longitude,
+            "userId", organization,
+            "observationDateTime", species, count,
+            "monitoringCode", "startDateTime", "endDateTime", confidential,
+            "autoLocationEn", "autoLocationLocal", "autoLocationLang",
+            "bgatlas2008UtmCode"
+          FROM "FormCBM"
+
+          UNION ALL
+
+          SELECT
+            'FormCiconia' as form_name, id,
+            latitude, longitude,
+            "userId", organization,
+            "observationDateTime", 'Ciconia ciconia' as species, NULL::integer as count,
+            "monitoringCode", "startDateTime", "endDateTime", confidential,
+            "autoLocationEn", "autoLocationLocal", "autoLocationLang",
+            "bgatlas2008UtmCode"
+          FROM "FormCiconia"
+        ) birds_observations
+    `)
   }
 }

--- a/server/migrations/20211101123223-create-view-bgatlas2008-stats-methodology.js
+++ b/server/migrations/20211101123223-create-view-bgatlas2008-stats-methodology.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const tableName = 'bgatlas2008_stats_methodology'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    if (queryInterface.sequelize.options.dialect !== 'postgres') return
+    await queryInterface.sequelize.query(`
+      CREATE OR REPLACE VIEW ${tableName} AS
+      SELECT
+        bgatlas2008_utm_code as utm_code,
+        observation_methodology_en as observation_methodology,
+        count(*) as records_count
+      FROM birds_observations
+      WHERE bgatlas2008_utm_code IS NOT NULL
+        AND bgatlas2008_utm_code != ''
+      GROUP BY
+        bgatlas2008_utm_code,
+        observation_methodology_en
+    `)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    if (queryInterface.sequelize.options.dialect !== 'postgres') return
+    await queryInterface.sequelize.query(`DROP VIEW IF EXISTS ${tableName}`)
+  }
+}

--- a/server/migrations/20211101123223-create-view-bgatlas2008-stats-methodology.js
+++ b/server/migrations/20211101123223-create-view-bgatlas2008-stats-methodology.js
@@ -8,15 +8,20 @@ module.exports = {
     await queryInterface.sequelize.query(`
       CREATE OR REPLACE VIEW ${tableName} AS
       SELECT
-        bgatlas2008_utm_code as utm_code,
-        observation_methodology_en as observation_methodology,
-        count(*) as records_count
-      FROM birds_observations
-      WHERE bgatlas2008_utm_code IS NOT NULL
-        AND bgatlas2008_utm_code != ''
+        utm_code,
+        observation_methodology,
+        (count(*))::integer as records_count
+      FROM (
+        SELECT
+          bgatlas2008_utm_code as utm_code,
+          COALESCE(observation_methodology_en, '') as observation_methodology
+        FROM birds_observations
+        WHERE bgatlas2008_utm_code IS NOT NULL
+          AND bgatlas2008_utm_code != ''
+      ) as t
       GROUP BY
-        bgatlas2008_utm_code,
-        observation_methodology_en
+        utm_code,
+        observation_methodology
     `)
   },
 

--- a/server/models/bgatlas2008_stats_methodology.js
+++ b/server/models/bgatlas2008_stats_methodology.js
@@ -1,0 +1,36 @@
+'use strict'
+module.exports = function (sequelize, Sequelize) {
+  return sequelize.define('bgatlas2008_stats_methodology', {
+    utm_code: { type: Sequelize.STRING(4), primaryKey: true },
+    observation_methodology: { type: Sequelize.STRING(), primaryKey: true },
+    records_count: { type: Sequelize.INTEGER }
+  }, {
+    tableName: 'bgatlas2008_stats_methodology',
+    timestamps: false,
+    underscored: true,
+    classMethods: {
+      associate: function (models) {
+        models.bgatlas2008_stats_methodology.hasOne(models.bgatlas2008_cells, {
+          as: 'utmCoordinates',
+          sourceKey: 'utm_code',
+          foreignKey: 'utm_code'
+        })
+      }
+    },
+    instanceMethods: {
+      apiData () {
+        const data = {
+          utm_code: this.utm_code,
+          observation_methodology: this.observation_methodology,
+          records_count: this.records_count
+        }
+
+        if (this.utmCoordinates) {
+          data.coordinates = this.utmCoordinates.coordinates()
+        }
+
+        return data
+      }
+    }
+  })
+}


### PR DESCRIPTION
- [x] add `observationMethodology` to `birds_observations`
- [ ] extend `bgatlas2008_cell_stats` action to return to moderators all users and record counts from `bgatlas2008_stats_user`
- [ ] create view to group by `utm_code` and `observationMethodologyEn` from `birds_observation`
- [ ] create action to return to moderators observationMethodology and record count
- [ ] create table `bgatlas2008_cell_status` with boolean field `completed`, defaults to false
- [ ] create moderator only action to set completed and delete `bgatlas2008_user_selected`
- [ ] create org admin only action to clear completed
