### PR TITLE
fix(ciconia): properly export FormCiconia approximateDate fields

### DIFF
--- a/__tests__/__snapshots__/db-schema.js.snap
+++ b/__tests__/__snapshots__/db-schema.js.snap
@@ -5,6 +5,8 @@ exports[`db schema: schema 1`] = `
 -- PostgreSQL database dump
 --
 
+\\\\restrict AAAAAAAAAA
+
 
 
 
@@ -5601,6 +5603,8 @@ CREATE OR REPLACE VIEW public.cbm_stats AS
 --
 -- PostgreSQL database dump complete
 --
+
+\\\\unrestrict AAAAAAAAAA
 
 "
 `;

--- a/__tests__/db-schema.js
+++ b/__tests__/db-schema.js
@@ -6,7 +6,7 @@ const api = setup.api
 
 test('db schema', async () => {
   const { error, stdout, stderr } = await new Promise((resolve) => {
-    exec('pg_dump --schema-only --format=plain --no-owner --no-privileges', {
+    exec(`pg_dump --schema-only --format=plain --no-owner --no-privileges --restrict-key='${'A'.repeat(10)}'`, {
       env: {
         PGHOST: api.config.sequelize.host,
         PGPORT: api.config.sequelize.port,

--- a/server/forms/ciconia.js
+++ b/server/forms/ciconia.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const { assign } = Object
+const moment = require('moment')
 const bgatlas2008 = require('./_fields/bgatlas2008')
 const newSpeciesModeratorReview = require('./_fields/newSpeciesModeratorReview')
 const etrs89GridCode = require('./_fields/etrs89GridCode')
@@ -139,3 +140,11 @@ exports.simpleExportFields = [
   'speciesNotes',
   'notes'
 ]
+
+exports.prepareCsv = async function (api, record, csv) {
+  return {
+    ...csv,
+    approximateDateStorksAppeared: record.approximateDateStorksAppeared ? moment.tz(record.approximateDateStorksAppeared, api.config.formats.tz).format(api.config.formats.date) : '',
+    approximateDateDisappearanceWhiteStorks: record.approximateDateDisappearanceWhiteStorks ? moment.tz(record.approximateDateDisappearanceWhiteStorks, api.config.formats.tz).format(api.config.formats.date) : ''
+  }
+}


### PR DESCRIPTION
Properly export approximateDateStorksAppeared and approximateDateDisappearanceWhiteStorks fields as dates instead of timestamps.