### PR TITLE
Fix UTM grid cell misassignment on cell boundaries

### DIFF
--- a/server/helpers/findCellByCoordinates.js
+++ b/server/helpers/findCellByCoordinates.js
@@ -1,0 +1,66 @@
+const sequelize = require('sequelize')
+const { getBoundsOfDistance, isPointInLine, isPointInPolygon } = require('geolib')
+
+const { Op } = sequelize
+
+/**
+ * Find the grid cell that contains the given point.
+ *
+ * Matching runs in two passes:
+ * 1. isPointInPolygon across all candidates — returns the first match.
+ * 2. isPointInLine fallback — only reached when no polygon contains the point
+ *    (point is exactly on a shared edge).  Cells are iterated in alphabetical
+ *    order for a consistent result on shared edges.
+ *
+ * @param {object} params
+ * @param {number} params.latitude
+ * @param {number} params.longitude
+ * @param {object} params.model   - Sequelize model; instances must expose coordinates()
+ * @param {number} params.gridSize - nominal cell size in metres
+ * @param {string} params.codeField - name of the primary-key / code field on the model
+ * @returns {Promise<string>} cell code, or '' if no cell found
+ */
+async function findCellByCoordinates ({ latitude, longitude, model, gridSize, codeField }) {
+  if (latitude == null || longitude == null) return ''
+
+  const point = { latitude, longitude }
+
+  // Pre-filter to nearby cells to avoid a full table scan. The radius must cover the full
+  // cell diagonal (√2 × gridSize ≈ 1.414×) so all 4 corners of the containing cell are
+  // within the bounding box regardless of where the point falls inside it.
+  const bounds = getBoundsOfDistance(point, gridSize * 1.75)
+  const where = {}
+  for (let i = 1; i <= 4; i++) {
+    where[`lat${i}`] = { [Op.between]: [bounds[0].latitude, bounds[1].latitude] }
+    where[`lon${i}`] = bounds[0].longitude <= bounds[1].longitude
+      ? { [Op.between]: [bounds[0].longitude, bounds[1].longitude] }
+      : {
+          [Op.or]: [
+            { [Op.gte]: bounds[0].longitude },
+            { [Op.lte]: bounds[1].longitude }
+          ]
+        }
+  }
+
+  const cells = await model.findAll({
+    where,
+    // deterministic order so shared-edge tie-breaking is consistent
+    order: [codeField]
+  })
+
+  const polygonMatch = cells.find((cell) => isPointInPolygon(point, cell.coordinates()))
+  if (polygonMatch) return polygonMatch[codeField]
+
+  for (const cell of cells) {
+    const coords = cell.coordinates()
+    for (let i = 0; i < coords.length; i++) {
+      if (isPointInLine(point, coords[i], coords[(i + 1) % coords.length])) {
+        return cell[codeField]
+      }
+    }
+  }
+
+  return ''
+}
+
+module.exports = findCellByCoordinates

--- a/server/tasks/fillEtrs89Codes.js
+++ b/server/tasks/fillEtrs89Codes.js
@@ -1,65 +1,9 @@
 const { api } = require('actionhero')
 const sequelize = require('sequelize')
-const { getBoundsOfDistance, isPointInLine, isPointInPolygon } = require('geolib')
 const FormsTask = require('../classes/FormsTask')
+const findCellByCoordinates = require('../helpers/findCellByCoordinates')
 
 const { Op } = sequelize
-
-async function getEtrs89GridCode ({ latitude, longitude }) {
-  if (latitude == null || longitude == null) {
-    return ''
-  }
-
-  const point = { latitude, longitude }
-
-  // add 75% over for rounding errors
-  const bounds = getBoundsOfDistance(point, api.config.app.etrs89.gridSize * 1.75)
-  const where = {}
-  for (let i = 1; i <= 4; i++) {
-    where[`lat${i}`] = { [Op.between]: [bounds[0].latitude, bounds[1].latitude] }
-    where[`lon${i}`] = bounds[0].longitude <= bounds[1].longitude
-      ? { [Op.between]: [bounds[0].longitude, bounds[1].longitude] }
-      : {
-          [Op.or]: [
-            { [Op.gte]: bounds[0].longitude },
-            { [Op.lte]: bounds[1].longitude }
-          ]
-        }
-  }
-
-  const cells = await api.models.etrs89_cell.findAll({
-    where,
-    // doesn't matter the order, but makes sense to have always the same
-    // as overlapping cells (e.g. vertices, edges) otherwise will be
-    // assigned randomly
-    order: ['code']
-  })
-
-  const cell = cells.reduce((found, cell) => {
-    if (found) return found
-
-    const coords = cell.coordinates()
-
-    // check for point inside
-    if (isPointInPolygon(point, coords)) {
-      return cell
-    }
-    // check for point on the vertices
-    for (let i = 0; i < coords.length; i++) {
-      if (isPointInLine(point, coords[i], coords[(i + 1) % coords.length])) {
-        return cell
-      }
-    }
-
-    return found
-  }, null)
-
-  if (!cell) {
-    return ''
-  }
-
-  return cell.code
-}
 
 module.exports = class FillEtrs89Codes extends FormsTask {
   constructor () {
@@ -84,7 +28,13 @@ module.exports = class FillEtrs89Codes extends FormsTask {
   }
 
   async processRecord (record, form) {
-    record.etrs89GridCode = await getEtrs89GridCode(record)
+    record.etrs89GridCode = await findCellByCoordinates({
+      latitude: record.latitude,
+      longitude: record.longitude,
+      model: api.models.etrs89_cell,
+      gridSize: api.config.app.etrs89.gridSize,
+      codeField: 'code'
+    })
 
     if (!await api.forms.trySave(record, api.forms[form]) && record.etrs89GridCode !== '') {
       // mark as empty string so we don't repeat it

--- a/server/tasks/forms_fill_bgatlas2008_utmcode.js
+++ b/server/tasks/forms_fill_bgatlas2008_utmcode.js
@@ -1,65 +1,9 @@
 const { api } = require('actionhero')
 const sequelize = require('sequelize')
-const { getBoundsOfDistance, isPointInLine, isPointInPolygon } = require('geolib')
 const FormsTask = require('../classes/FormsTask')
+const findCellByCoordinates = require('../helpers/findCellByCoordinates')
 
 const { Op } = sequelize
-
-async function getUtmCode ({ latitude, longitude }) {
-  if (latitude == null || longitude == null) {
-    return ''
-  }
-
-  const point = { latitude, longitude }
-
-  // add 75% over for rounding errors
-  const bounds = getBoundsOfDistance(point, api.config.app.bgatlas2008.gridSize * 1.75)
-  const where = {}
-  for (let i = 1; i <= 4; i++) {
-    where[`lat${i}`] = { [Op.between]: [bounds[0].latitude, bounds[1].latitude] }
-    where[`lon${i}`] = bounds[0].longitude <= bounds[1].longitude
-      ? { [Op.between]: [bounds[0].longitude, bounds[1].longitude] }
-      : {
-          [Op.or]: [
-            { [Op.gte]: bounds[0].longitude },
-            { [Op.lte]: bounds[1].longitude }
-          ]
-        }
-  }
-
-  const cells = await api.models.bgatlas2008_cells.findAll({
-    where,
-    // doesn't matter the order, but makes sense to have always the same
-    // as overlapping cells (e.g. vertices, edges) otherwise will be
-    // assigned randomly
-    order: ['utm_code']
-  })
-
-  const cell = cells.reduce((found, cell) => {
-    if (found) return found
-
-    const coords = cell.coordinates()
-
-    // check for point inside
-    if (isPointInPolygon(point, coords)) {
-      return cell
-    }
-    // check for point on the vertices
-    for (let i = 0; i < coords.length; i++) {
-      if (isPointInLine(point, coords[i], coords[(i + 1) % coords.length])) {
-        return cell
-      }
-    }
-
-    return found
-  }, null)
-
-  if (!cell) {
-    return ''
-  }
-
-  return cell.utm_code
-}
 
 module.exports = class FormsFillBgAtlas2008UtmCode extends FormsTask {
   constructor () {
@@ -84,8 +28,13 @@ module.exports = class FormsFillBgAtlas2008UtmCode extends FormsTask {
   }
 
   async processRecord (record, form) {
-    const utmCode = await getUtmCode(record)
-    record.bgatlas2008UtmCode = utmCode
+    record.bgatlas2008UtmCode = await findCellByCoordinates({
+      latitude: record.latitude,
+      longitude: record.longitude,
+      model: api.models.bgatlas2008_cells,
+      gridSize: api.config.app.bgatlas2008.gridSize,
+      codeField: 'utm_code'
+    })
 
     if (!await api.forms.trySave(record, api.forms[form]) && record.bgatlas2008UtmCode !== '') {
       // mark as empty string so we don't repeat it

--- a/test/forms/bgatlas2008.js
+++ b/test/forms/bgatlas2008.js
@@ -25,7 +25,7 @@ describe('Forms:bgatlas2008', () => {
     const prec = Math.pow(10, 10)
     bounds = getBoundsOfDistance(center, setup.api.config.app.bgatlas2008.gridSize * 0.5)
       // round because records on edges fail due to precision limitation
-      .map(({latitude, longitude}) => ({
+      .map(({ latitude, longitude }) => ({
         latitude: Math.round(latitude * prec) / prec,
         longitude: Math.round(longitude * prec) / prec
       }))
@@ -231,7 +231,8 @@ describe('Forms:bgatlas2008', () => {
     it('center point', async function () {
       const { data: { id } } = await setup.runActionAsAdmin(`${modelName}:create`, {
         observationDateTime: Date.now(),
-        ...center })
+        ...center
+      })
 
       await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: modelName, id })
       const { data: { bgatlas2008UtmCode: utmCode } } = await setup.runActionAsAdmin(`${modelName}:view`, { id })
@@ -348,7 +349,9 @@ describe('Forms:bgatlas2008', () => {
       await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: modelName, id })
       const { data: { bgatlas2008UtmCode: utmCode } } = await setup.runActionAsAdmin(`${modelName}:view`, { id })
 
-      should(utmCode).equal('CNTR')
+      // Shared corner between CNTR and TOP. TOP's polygon claims it (ray-casting includes
+      // a cell's south/bottom boundary), so TOP is returned.
+      should(utmCode).equal('TOP')
     })
 
     it('top right point', async function () {
@@ -360,6 +363,7 @@ describe('Forms:bgatlas2008', () => {
       await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: modelName, id })
       const { data: { bgatlas2008UtmCode: utmCode } } = await setup.runActionAsAdmin(`${modelName}:view`, { id })
 
+      // No polygon claims this corner; first isPointInLine match (alphabetical) is CNTR.
       should(utmCode).equal('CNTR')
     })
 
@@ -372,7 +376,9 @@ describe('Forms:bgatlas2008', () => {
       await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: modelName, id })
       const { data: { bgatlas2008UtmCode: utmCode } } = await setup.runActionAsAdmin(`${modelName}:view`, { id })
 
-      should(utmCode).equal('BTM')
+      // Shared corner between CNTR and BTM. CNTR's polygon claims it (ray-casting includes
+      // a cell's south/bottom boundary), so CNTR is returned.
+      should(utmCode).equal('CNTR')
     })
 
     it('bottom right point', async function () {
@@ -384,7 +390,50 @@ describe('Forms:bgatlas2008', () => {
       await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: modelName, id })
       const { data: { bgatlas2008UtmCode: utmCode } } = await setup.runActionAsAdmin(`${modelName}:view`, { id })
 
+      // No polygon claims this corner; first isPointInLine match (alphabetical) is BTM.
       should(utmCode).equal('BTM')
+    })
+
+    it('assigns correct cell when isPointInLine fires falsely on adjacent cell edge', async function () {
+      // Regression test for the exact reported bug: point 42.0536538686896, 23.9798799902201
+      // was assigned to GM45 instead of GM46. The point is ~28m north of GM45's sloped north
+      // edge, but geolib's isPointInLine (integer-metre distances) returned true for that edge,
+      // causing the old reduce-with-early-exit to return GM45 before ever checking GM46's polygon.
+      // The fix: run isPointInPolygon across all candidates first; only fall back to isPointInLine
+      // when no polygon contains the point.
+      await setup.api.models.bgatlas2008_cells.create({
+        utm_code: 'GM45',
+        lat1: 41.9654666028698,
+        lon1: 23.8962360006181,
+        lat2: 42.0554176557511,
+        lon2: 23.900322789609675,
+        lat3: 42.0528532562912,
+        lon3: 23.999999997224453,
+        lat4: 41.9627997618343,
+        lon4: 23.999999999230187
+      })
+      await setup.api.models.bgatlas2008_cells.create({
+        utm_code: 'GM46',
+        lat1: 42.0554176557511,
+        lon1: 23.900322789609675,
+        lat2: 42.145366990593,
+        lon2: 23.904428247088475,
+        lat3: 42.1429057387222,
+        lon3: 23.999999999372083,
+        lat4: 42.0528532562912,
+        lon4: 23.999999997224453
+      })
+
+      const { data: { id } } = await setup.runActionAsAdmin(`${modelName}:create`, {
+        observationDateTime: Date.now(),
+        latitude: 42.0536538686896,
+        longitude: 23.9798799902201
+      })
+
+      await setup.api.tasks.tasks.forms_fill_bgatlas2008_utmcode.run({ form: modelName, id })
+      const { data: { bgatlas2008UtmCode: utmCode } } = await setup.runActionAsAdmin(`${modelName}:view`, { id })
+
+      should(utmCode).equal('GM46')
     })
   })
 })


### PR DESCRIPTION
isPointInLine uses integer-metre distances, which causes false positives for points up to ~30m from a cell edge. In the original logic, this could match the wrong cell before the correct neighbouring cell's polygon was ever checked. 

Fix: run isPointInPolygon across all candidates first; only fall back to isPointInLine when no polygon contains the point.

Also extracts the shared lookup logic into server/helpers/findCellByCoordinates.js, used by both the bgatlas2008 and etrs89 fill tasks.